### PR TITLE
Speed up & refine derived trace rendering

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if (MSVC)
 endif (MSVC)
 
 if (NOT CMAKE_CXX_FLAGS)
-    set(CMAKE_CXX_FLAGS "-O2 -ggdb")
+    set(CMAKE_CXX_FLAGS "-O2 -ggdb -march=native")
 endif (NOT CMAKE_CXX_FLAGS)
 
 # This only works in cmake >3.1

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -19,20 +19,39 @@
 
 #include "frequencydemod.h"
 #include <liquid/liquid.h>
+#include <liquid/liquid.h>
 #include "util.h"
 
 FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src)
 {
+    // create the demodulator once
+    fdem_ = freqdem_create(relativeBandwidth() / 2.0);
+}
 
+FrequencyDemod::~FrequencyDemod()
+{
+    // destroy the demodulator
+    freqdem_destroy(fdem_);
 }
 
 void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
 {
-    auto in = static_cast<std::complex<float>*>(input);
+    auto in  = static_cast<std::complex<float>*>(input);
     auto out = static_cast<float*>(output);
-    freqdem fdem = freqdem_create(relativeBandwidth() / 2.0);
+    // decimation factor: reduce output points to match trace tile width
+    size_t decim = (count > 1000) ? size_t(count / 1000) : 1;
+    float lastDem = 0.0f;
+    // run filter on every sample to maintain state, but only store every decim-th output
     for (int i = 0; i < count; i++) {
-        freqdem_demodulate(fdem, in[i], &out[i]);
+        float dem;
+        freqdem_demodulate(fdem_, in[i], &dem);
+        lastDem = dem;
+        if (static_cast<size_t>(i) % decim == 0) {
+            out[i] = dem;
+        }
     }
-    freqdem_destroy(fdem);
+    // ensure last sample is output
+    if (count > 0 && (size_t(count - 1) % decim) != 0) {
+        out[count - 1] = lastDem;
+    }
 }

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -25,5 +25,9 @@ class FrequencyDemod : public SampleBuffer<std::complex<float>, float>
 {
 public:
     FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
+    virtual ~FrequencyDemod();
     void work(void *input, void *output, int count, size_t sampleid) override;
+private:
+    // Liquid-DSP frequency demodulator object
+    freqdem      fdem_;
 };

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -18,6 +18,7 @@
  */
 
 #pragma once
+#include <liquid/liquid.h>
 
 #include "samplebuffer.h"
 
@@ -30,4 +31,11 @@ public:
 private:
     // Liquid-DSP frequency demodulator object
     freqdem      fdem_;
+    // if true, use fast instantaneous-frequency demod instead of full FIR
+    bool         cheapMode_ = false;
+public:
+    /**
+     * Toggle fast-path demodulation mode (instantaneous phase diff).
+     */
+    void setCheapDemod(bool enabled) { cheapMode_ = enabled; }
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -55,6 +55,12 @@ MainWindow::MainWindow()
     connect(dock->annoLabelCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableAnnoLabels);
     connect(dock->commentsCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableAnnotationCommentsTooltips);
     connect(dock->annoColorCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableAnnoColors);
+    // Connect derived plot height adjustment
+    connect(dock, &SpectrogramControls::derivedHeightChanged, plots, &PlotView::setDerivedPlotHeight);
+    // fast-path FM demodulation toggle
+    connect(dock, &SpectrogramControls::fastDemodChanged, plots, &PlotView::enableFastDemod);
+    // allow user to control number of threads in the Qt thread pool
+    connect(dock, &SpectrogramControls::threadsChanged, plots, &PlotView::setMaxThreads);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
 
     // Connect dock outputs

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -62,6 +62,15 @@ public slots:
     void setFFTAndZoom(int fftSize, int zoomLevel);
     void setPowerMin(int power);
     void setPowerMax(int power);
+    void setDerivedPlotHeight(int height);
+    /**
+     * Enable or disable the fast-path (cheap) FM demodulation mode
+     */
+    void enableFastDemod(bool enabled);
+    /**
+     * Set maximum threads for background tile rendering.
+     */
+    void setMaxThreads(int threads);
 
 protected:
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -108,4 +117,5 @@ private:
 
     int sampleToColumn(size_t sample);
     size_t columnToSample(int col);
+    int derivedPlotHeight;
 };

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -106,6 +106,29 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     annoColorCheckBox = new QCheckBox(widget);
     layout->addRow(new QLabel(tr("Annotation Colors:")), annoColorCheckBox);
 
+    // Derived plots settings
+    layout->addRow(new QLabel()); // spacer
+    layout->addRow(new QLabel(tr("<b>Derived Plots</b>")));
+    derivedPlotHeightSpinBox = new QSpinBox(widget);
+    derivedPlotHeightSpinBox->setRange(20, 1000);
+    derivedPlotHeightSpinBox->setValue(200);
+    layout->addRow(new QLabel(tr("Plot height:")), derivedPlotHeightSpinBox);
+    connect(derivedPlotHeightSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &SpectrogramControls::derivedHeightChanged);
+    // Fast-path instantaneous-frequency FM demodulation
+    fastDemodCheckBox = new QCheckBox(widget);
+    fastDemodCheckBox->setCheckState(Qt::Unchecked);
+    layout->addRow(new QLabel(tr("Fast-path FM demod:")), fastDemodCheckBox);
+    connect(fastDemodCheckBox, &QCheckBox::toggled,
+            this, &SpectrogramControls::fastDemodChanged);
+    // Thread count for concurrent tile rendering
+    threadCountSpinBox = new QSpinBox(widget);
+    threadCountSpinBox->setRange(1, 64);
+    threadCountSpinBox->setValue(8);
+    layout->addRow(new QLabel(tr("Threads:")), threadCountSpinBox);
+    connect(threadCountSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &SpectrogramControls::threadsChanged);
+
     widget->setLayout(layout);
     setWidget(widget);
 

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -39,6 +39,13 @@ public:
 signals:
     void fftOrZoomChanged(int fftSize, int zoomLevel);
     void openFile(QString fileName);
+    void derivedHeightChanged(int height);
+    // toggle fast-path (instantaneous) frequency demod in derived trace plot
+    void fastDemodChanged(bool enabled);
+    /**
+     * Requested number of threads to use for tile rendering.
+     */
+    void threadsChanged(int threads);
 
 public slots:
     void timeSelectionChanged(float time);
@@ -78,4 +85,11 @@ public:
     QCheckBox *annoLabelCheckBox;
     QCheckBox *commentsCheckBox;
     QCheckBox *annoColorCheckBox;
+    QSpinBox *derivedPlotHeightSpinBox;
+    // fast (cheap) demodulation mode for FM traces
+    QCheckBox *fastDemodCheckBox;
+    /**
+     * Spinbox to select number of threads for concurrent tasks.
+     */
+    QSpinBox   *threadCountSpinBox;
 };


### PR DESCRIPTION
1. Debounce + early‑exit tile rendering so stale background jobs never finish drawing.
2. Hoist Liquid‑DSP freqdem creation into constructor and add on‑the‑fly down‑sampling to 1px resolution.
3. Add “Fast‑path FM demod” (instantaneous phase) toggle, and UI “Threads” spinner to control how many cores QtConcurrent uses.
4. Dynamically split each trace window into N per‑thread tiles, fully saturating the worker pool for max parallelism.
5. Enable `-march=native` in CMake to pull in hardware‑accelerated dot‑product kernels.
