### PR TITLE
ui: keep the GUI thread responsive during retune, pan, and parameter drags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+inspectrum is a Qt5 desktop application for analysing captured signals from software-defined radio receivers. Large (100GB+) raw IQ files are memory-mapped and rendered into a spectrogram plus a stack of derived plots (amplitude, frequency, phase, IQ, threshold). This fork (`ncasaril/*`) adds performance knobs on top of upstream `miek/inspectrum`: a fast-path FM demod, configurable derived-plot height, and multi-threaded tile rendering.
+
+## Build and run
+
+```bash
+# Out-of-tree build (build/ already exists in this checkout)
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+./build/src/inspectrum [file]
+
+# Run tests (CI runs ctest, but there are currently no registered tests)
+ctest --test-dir build
+```
+
+Dependencies: cmake ≥ 3.1, Qt5 (Widgets + Concurrent), FFTW 3.x, liquid-dsp ≥ 1.3.0, pkg-config. On Ubuntu: `libfftw3-dev libliquid-dev qtbase5-dev`. CI (`.github/workflows/build.yml`) builds against macOS and Ubuntu 20.04/22.04.
+
+Default compile flags when unset: `-O2 -ggdb -march=native`, C++14, `AUTOMOC` on. All source lives under `src/`; adding a `.cpp` requires appending it to `inspectrum_sources` in `src/CMakeLists.txt`.
+
+## Architecture
+
+### Sample-source pipeline (the spine of the app)
+
+Every data flow in inspectrum is a chain of `SampleSource<T>` objects. Downstream nodes pull samples on demand via `getSamples(start, length)` — there is no push/streaming path.
+
+- `AbstractSampleSource` (`abstractsamplesource.h`) — type-erased base; carries the subscriber set and the runtime `sampleType()` (a `std::type_index`) used for plot compatibility.
+- `SampleSource<T>` (`samplesource.h`) — templated node producing `T` (typically `std::complex<float>` or `float`). Also owns the per-node `annotationList` and `frequency`.
+- `SampleBuffer<Tin, Tout>` (`samplebuffer.h`) — bridge that pulls `Tin` from an upstream source, calls a subclass-defined `work()` to transform to `Tout`, and exposes the result as a `SampleSource<Tout>`. Almost every derived plot sits on top of a `SampleBuffer`.
+- Leaves/transforms: `InputSource` (mmap'd file → `complex<float>`), `TunerTransform` (mix + FIR bandpass via liquid-dsp), `FrequencyDemod` / `AmplitudeDemod` / `PhaseDemod` (complex → float), `Threshold` (float → float).
+
+Invalidation uses the `Subscriber` interface (`subscriber.h`): when an upstream source changes (new file, tuner moved, demod parameter toggled) it calls `invalidate()`, which fans out `invalidateEvent()` to every subscriber. Plots react by dropping cached tiles and re-requesting samples. Keep this contract intact when adding new transforms — forgetting to forward `invalidateEvent` produces stale tiles that only refresh on scroll.
+
+### Plot layer
+
+- `Plot` (`plot.h`) is a `QObject` that wraps one `AbstractSampleSource` and exposes `paintBack` / `paintMid` / `paintFront` hooks. Its `output()` may differ from its input (e.g. `SpectrogramPlot` returns the `TunerTransform` output so downstream derived plots see the tuned/filtered signal).
+- `SpectrogramPlot` is the top plot; it owns the `FFT`, a colormap, a pixmap tile cache keyed by `(fftSize, zoomLevel, nfftSkip, sample)`, and the `Tuner` + `TunerTransform`. Tile size is fixed at 65536 samples (must be a multiple of max FFT size).
+- `TracePlot` is the base for all derived scalar plots. It uses a debounced tile scheduler, `QtConcurrent` background workers (`QFutureWatcher`), and a global-min/max background pass for float sources. **Recent change**: `paintMid` now splits each visible region into N tiles (N = thread count) so rendering scales with cores.
+- `Plots` (`plots.h`) is a static registry mapping a sample `type_index` to the list of plots that can consume it. This is how the right-click "add derived plot" menu is populated — to add a new plot type, register it here and it will automatically be offered wherever the sample type matches.
+- `PlotView` (`plotview.h`) is the `QGraphicsView` that stacks plots vertically, owns cursors, the input source, and funnels mouse/wheel events. Scroll position and zoom are translated to a sample range that every plot paints against.
+
+### UI
+
+`MainWindow` hosts the `PlotView` and the `SpectrogramControls` dock widget. Controls emit signals that land on `PlotView` / `SpectrogramPlot` slots — there is no central controller. New UI knobs typically need: a widget in `SpectrogramControls`, a `signal` on the dock, a `slot` on `PlotView` (or the relevant plot), and wiring in `MainWindow`.
+
+### File formats
+
+`InputSource` mmaps the file and uses a `SampleAdapter` subclass to convert on the fly to `complex<float>`. Extension → adapter mapping lives in `inputsource.cpp`; SigMF `.sigmf-meta` / `.sigmf-data` pairs are parsed via `readMetaData()` and populate `annotationList`. Unknown extensions default to `cf32`. Everything internal is 32-bit — 64-bit inputs are truncated on read.
+
+## Conventions
+
+- **Match upstream style.** This is a fork of `miek/inspectrum`; keep header guards as `#pragma once`, GPL-3 license blocks at the top of new files, and two-space indent to match existing code.
+- **Derived-plot additions** go through the `Plots` registry, not ad-hoc wiring in `PlotView`.
+- **Heavy per-tile work belongs off the GUI thread.** Use `QtConcurrent::run` + `QFutureWatcher` like `TracePlot` does, and respect the thread-count setting plumbed through `PlotView::setMaxThreads`.
+- **Cache keys must include every parameter that affects output** (see `TileCacheKey` for the spectrogram pattern). Forgetting one produces subtle stale-tile bugs that only surface when the user toggles that parameter.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,3 +3,4 @@ project(inspectrum CXX)
 enable_testing()
 
 add_subdirectory(src)
+add_subdirectory(tools)

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -20,6 +20,7 @@
 #include "frequencydemod.h"
 #include <liquid/liquid.h>
 #include <QMutexLocker>
+#include <cmath>
 #include <complex>
 #include <algorithm>
 #include <vector>
@@ -169,4 +170,13 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
 
     applyPostLpf(out, count);
     applyPostDecimation(out, count, sampleid);
+
+    // Scrub non-finite values: freqdem's cold-start near sampleid=0 can
+    // produce NaN/Inf when the tuner's fresh FIR feeds it near-zero-magnitude
+    // samples, and NaN can then propagate through the rest of the chunk.
+    // Downstream (min/max scan, painter path) are finite-only, so replace
+    // any junk with zero.
+    for (int i = 0; i < count; ++i) {
+        if (!std::isfinite(out[i])) out[i] = 0.0f;
+    }
 }

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -569,6 +569,20 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
         demod.assign(batchLen, 0.0f);
     }
 
+    // Scale freqdem's normalised output (m ∈ [-1, 1] for full ±kf·Fs
+    // deviation) to instantaneous frequency in Hz: f = m · kf · Fs. Doing
+    // this at the source means the plot's Y-axis labels read in Hz and
+    // the hover value just appends "Hz" — no double-conversion anywhere.
+    // Cheap mode (phase-diff path) gives `arg` per sample which is
+    // already 2π·f/Fs, so its Hz scale is Fs/(2π) instead.
+    {
+        const double scale = cheap
+            ? (fs / (2.0 * M_PI))
+            : (0.49 * fs);
+        const float scalef = static_cast<float>(scale);
+        for (auto &s : demod) s *= scalef;
+    }
+
     // Small absolute file-start NaN mask for the upstream tuner's FIR
     // cold-start. The bilateral pad above handles *our* LPF, but the
     // tuner runs at full Fs upstream and its output samples [0..tuner_taps]
@@ -714,6 +728,17 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
 
     applyPostLpf(out, count);
     applyPostDecimation(out, count, sampleid);
+
+    // Scale to instantaneous frequency in Hz (see fillBatchCache for the
+    // matching scaling on the batched path). Y-axis labels and the hover
+    // value both read in Hz from this point on.
+    {
+        const double scale = cheapMode_
+            ? (rate() / (2.0 * M_PI))
+            : (0.49 * rate());
+        const float scalef = static_cast<float>(scale);
+        for (int i = 0; i < count; ++i) out[i] *= scalef;
+    }
 
     // Stats after the LPF (still pre-NaN-mark) so we can see what the filter
     // produced before the cold-start mask hides it.

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -252,28 +252,6 @@ void FrequencyDemod::rebuildPostLpf()
         postLpfLen_ = lpfSettleSamples_;
         break;
     }
-    case LpfMethod::EllipticIir: {
-        // Sharpest IIR transition for the order, at the cost of equiripple
-        // passband / stopband. Cascaded SOS keeps coefficients numerically
-        // well-conditioned at low normalized cutoffs.
-        const unsigned int order = 8;
-        const float Ap = 0.1f;   // passband ripple (dB)
-        const float As = 60.0f;  // stopband attenuation (dB)
-        postIir_ = iirfilt_rrrf_create_prototype(
-            LIQUID_IIRDES_ELLIP, LIQUID_IIRDES_LOWPASS, LIQUID_IIRDES_SOS,
-            order, static_cast<float>(cutoff), 0.0f, Ap, As);
-        // Filtfilt squares the magnitude response — the equiripple stopband
-        // ripple becomes ripple² (much smaller in linear scale). The earlier
-        // 3.2·N/cutoff_norm factor was sized for single-pass Elliptic where
-        // stopband residue rang for thousands of samples; with filtfilt the
-        // tail is much shorter, so 1.6·N/cutoff_norm is enough.
-        constexpr size_t kSettleCap = 500000;
-        double settle = 1.6 * order / cutoff;
-        if (settle > kSettleCap) settle = kSettleCap;
-        lpfSettleSamples_ = static_cast<size_t>(settle);
-        postLpfLen_ = lpfSettleSamples_;
-        break;
-    }
     }
 
     FmLog::instance().writef(
@@ -476,39 +454,52 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
                 }
             }
         } else if (postIir_) {
-            // Forward pass over the entire batch.
-            iirfilt_rrrf_reset(postIir_);
-            for (size_t i = 0; i < batchLen; ++i) {
-                iirfilt_rrrf_execute(postIir_, demod[i], &demod[i]);
+            // Filtfilt with bilateral constant padding. The forward pass
+            // cold-starts at the *start* of the buffer (state = 0); we pad
+            // the left with `first_sample` so the forward filter settles
+            // to that constant in the pad, then enters the data already
+            // matched at the boundary. The reverse pass cold-starts at the
+            // *end* of the buffer; we pad the right with the *forward
+            // pass*'s last output value (after running forward) so the
+            // reverse filter settles to that constant in its pad, then
+            // enters the data with the right initial conditions.
+            //
+            // Net result: the entire data region is fully settled for both
+            // passes — no NaN cold-start window needed at the start of the
+            // file, no boundary transients anywhere.
+            const size_t leftPad  = std::min<size_t>(settle, batchLen);
+            const size_t rightPad = std::min<size_t>(settle, batchLen);
+            std::vector<float> ext(leftPad + batchLen + rightPad);
+            const float first = batchLen > 0 ? demod[0] : 0.0f;
+            for (size_t i = 0; i < leftPad; ++i) ext[i] = first;
+            std::memcpy(ext.data() + leftPad, demod.data(),
+                        batchLen * sizeof(float));
+            // Right pad gets the data's last value before forward pass.
+            // The forward pass will smooth its output across the
+            // pad/data boundary; the *output* in the right pad ends up
+            // at whatever the filter settled to over the data, which is
+            // exactly what we want as the reverse pass's seed.
+            const float last = batchLen > 0 ? demod[batchLen - 1] : 0.0f;
+            for (size_t i = 0; i < rightPad; ++i) {
+                ext[leftPad + batchLen + i] = last;
             }
-            // Constant-pad on the right with the last forward-output value
-            // so the reverse pass cold-start happens in a benign region
-            // and settles to the same DC the data ends at.
-            const size_t pad = std::min<size_t>(settle, batchLen);
-            std::vector<float> tail(pad, demod.empty() ? 0.0f : demod.back());
-            // Reverse pass: pad first, then data, in reverse time order.
-            iirfilt_rrrf_reset(postIir_);
-            for (size_t i = 0; i < pad; ++i) {
-                float dummy;
-                iirfilt_rrrf_execute(postIir_, tail[i], &dummy);
-            }
-            for (size_t i = 0; i < batchLen; ++i) {
-                const size_t j = batchLen - 1 - i;
-                iirfilt_rrrf_execute(postIir_, demod[j], &demod[j]);
-            }
-        }
 
-        // Cold-start NaN mask: the file's first lpfSettleSamples_ are
-        // forward-pass transient and shouldn't bias the auto-scaling scan.
-        // Apply it in absolute (file-relative) coordinates so the same
-        // samples are masked regardless of which batch contains them.
-        const size_t coldStart = std::max<size_t>(512, settle);
-        if (start < coldStart) {
-            const size_t bad = std::min(coldStart - start, batchLen);
-            for (size_t i = 0; i < bad; ++i) {
-                demod[i] = std::numeric_limits<float>::quiet_NaN();
+            iirfilt_rrrf_reset(postIir_);
+            for (size_t i = 0; i < ext.size(); ++i) {
+                iirfilt_rrrf_execute(postIir_, ext[i], &ext[i]);
             }
+            iirfilt_rrrf_reset(postIir_);
+            for (size_t i = 0; i < ext.size(); ++i) {
+                const size_t j = ext.size() - 1 - i;
+                iirfilt_rrrf_execute(postIir_, ext[j], &ext[j]);
+            }
+            // Copy back just the data portion — both pads are discarded.
+            std::memcpy(demod.data(), ext.data() + leftPad,
+                        batchLen * sizeof(float));
         }
+        // No cold-start NaN window in batched mode: the bilateral pad
+        // above means sample 0 of the file is just as settled as any
+        // other sample, so there's nothing to hide.
     }
 
     batchCache_.startSample = start;

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -170,12 +170,19 @@ void FrequencyDemod::rebuildPostLpf()
 
     switch (postLpfMethod_) {
     case LpfMethod::KaiserFir: {
-        // Reference linear-phase FIR. Tap count from liquid's estimator at
-        // 60 dB stopband — this can be tens of thousands of taps for narrow
-        // cutoffs (slow, but the most accurate option).
+        // Reference linear-phase FIR. liquid's estimator wants tens of
+        // thousands of taps at narrow cutoffs (~7300 at fc/fs=5e-4 for 60 dB
+        // stopband); cap the length to keep per-tile cost bounded. At the
+        // cap the transition width widens (worse stop-band rejection at the
+        // very narrowest cutoffs) but visually it's still correct — the
+        // linear-phase response preserves wave shape, which is the whole
+        // reason this backend exists. 4096 taps gives ~9 kHz transition at
+        // 10 MHz Fs, more than adequate for FM-audio-rate cutoffs.
+        constexpr unsigned int kMaxTaps = 4096;
         const float atten = 60.0f;
         unsigned int len = estimate_req_filter_len(std::max(cutoff, 1e-4), atten);
         if (len < 3) len = 3;
+        if (len > kMaxTaps) len = kMaxTaps;
         std::vector<float> taps(len);
         liquid_firdes_kaiser(len, static_cast<float>(cutoff), atten, 0.0f, taps.data());
         // liquid_firdes_kaiser returns un-normalised taps — sum diverges from

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -27,6 +27,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <mutex>
 #include <thread>
@@ -257,12 +258,44 @@ void FrequencyDemod::applyPostLpf(float *out, int count)
             firfilt_rrrf_push(postFir_, out[i]);
             firfilt_rrrf_execute(postFir_, &out[i]);
         }
-    } else if (postIir_) {
-        iirfilt_rrrf_reset(postIir_);
-        for (int i = 0; i < count; ++i) {
-            iirfilt_rrrf_execute(postIir_, out[i], &out[i]);
+        return;
+    }
+    if (!postIir_) return;
+
+    // IIR backends run filtfilt (forward then reversed) so the visible plot
+    // gets a zero-phase response — the wave shape is preserved like a
+    // linear-phase FIR even though we're using cheap-per-sample biquads.
+    //
+    // Forward pass uses the leading SampleBuffer history to warm up. Reverse
+    // pass starts at the right-hand edge of the buffer and would corrupt the
+    // last lpfSettleSamples_ samples of every tile if run directly. Pad the
+    // right with edge-reflected samples (matches scipy.signal.filtfilt's
+    // default) so the reverse pass cold-start happens in the pad region and
+    // the real data is fully settled by the time it's reached.
+    const int pad = std::min<int>(static_cast<int>(lpfSettleSamples_),
+                                  std::max(count, 1));
+    std::vector<float> buf(static_cast<size_t>(count) + pad);
+    std::memcpy(buf.data(), out, count * sizeof(float));
+    if (pad > 0 && count > 0) {
+        // Odd reflection around the last sample: 2*last - x[count-2-i].
+        // Avoids introducing a step at the boundary that would itself ring.
+        const float last = out[count - 1];
+        for (int i = 0; i < pad; ++i) {
+            const int src = (count - 2 - i >= 0) ? (count - 2 - i) : 0;
+            buf[count + i] = 2.0f * last - out[src];
         }
     }
+
+    iirfilt_rrrf_reset(postIir_);
+    for (size_t i = 0; i < buf.size(); ++i) {
+        iirfilt_rrrf_execute(postIir_, buf[i], &buf[i]);
+    }
+    iirfilt_rrrf_reset(postIir_);
+    for (size_t i = 0; i < buf.size(); ++i) {
+        const size_t j = buf.size() - 1 - i;
+        iirfilt_rrrf_execute(postIir_, buf[j], &buf[j]);
+    }
+    std::memcpy(out, buf.data(), count * sizeof(float));
 }
 
 void FrequencyDemod::applyPostDecimation(float *out, int count, size_t sampleid)

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -110,13 +110,15 @@ void FrequencyDemod::rebuildPostLpf()
         LIQUID_IIRDES_ELLIP, LIQUID_IIRDES_LOWPASS, LIQUID_IIRDES_SOS,
         order, static_cast<float>(cutoff), 0.0f, Ap, As);
 
-    // Step-response settling time for a Butterworth lowpass scales like
-    // 1/cutoff_norm. Empirically ~4 / cutoff_norm samples gets us well past
-    // any visible overshoot ringing. Cap so a 1 Hz cutoff doesn't try to
-    // allocate gigabyte lead-ins; cap value chosen to keep history under
-    // ~1 MB of complex<float> upstream allocations.
-    constexpr size_t kSettleCap = 200000;
-    double settle = 4.0 / cutoff;
+    // Step-response settling for an Nth-order IIR lowpass scales as
+    // ~1.6·N / cutoff_norm samples to reach ~60 dB below peak ringing.
+    // Elliptic equiripple stopband can keep ringing past this nominal time,
+    // so add a 2× safety factor — the cold-start NaN window has to fully
+    // cover the transient or the auto-scaling y-axis chases the residual
+    // overshoot peaks at the start of the visible range. Cap the result so
+    // sub-Hz cutoffs don't try to allocate gigabytes of upstream lead-in.
+    constexpr size_t kSettleCap = 500000;
+    double settle = 3.2 * order / cutoff;
     if (settle > kSettleCap) settle = kSettleCap;
     lpfSettleSamples_ = static_cast<size_t>(settle);
     // postLpfLen_ feeds into historySize() so SampleBuffer fetches enough

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -24,12 +24,68 @@
 #include <cmath>
 #include <complex>
 #include <algorithm>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
 #include <limits>
+#include <mutex>
+#include <thread>
 #include <vector>
 
 // Toggle in one place — prints from the demod hot-path are noisy, so leave
 // these off by default and flip to 1 when chasing a regression.
 #define INSPECTRUM_FM_DEBUG 0
+
+namespace {
+// File-scoped, lazily-opened debug log. Activated by setting the env var
+// INSPECTRUM_FM_LOG to a filename (e.g. /tmp/inspectrum_fm.log). Writes are
+// serialised on a single mutex so multi-tile traces stay readable. The whole
+// thing is a no-op when the env var is unset, so leaving the support compiled
+// in costs nothing on a normal run.
+class FmLog {
+public:
+    static FmLog &instance() {
+        static FmLog s;
+        return s;
+    }
+    bool enabled() const { return file_ != nullptr; }
+    void writef(const char *fmt, ...) __attribute__((format(printf, 2, 3))) {
+        if (!file_) return;
+        std::lock_guard<std::mutex> lk(m_);
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(file_, fmt, ap);
+        va_end(ap);
+        fflush(file_);
+    }
+private:
+    FmLog() {
+        const char *p = std::getenv("INSPECTRUM_FM_LOG");
+        if (p && *p) {
+            file_ = std::fopen(p, "w");
+            if (file_) {
+                std::fprintf(file_, "# inspectrum FM demod log — fields: "
+                                    "tid sampleid count method cutoffHz coldStart "
+                                    "preNan finiteMin finiteMax postNan finiteMinAfter "
+                                    "finiteMaxAfter\n");
+                std::fflush(file_);
+            }
+        }
+    }
+    ~FmLog() { if (file_) std::fclose(file_); }
+    std::mutex m_;
+    std::FILE *file_ = nullptr;
+};
+
+const char *methodName(int m) {
+    switch (m) {
+    case 0: return "kaiserFir";
+    case 1: return "butterIir";
+    case 2: return "ellipIir";
+    default: return "unknown";
+    }
+}
+} // namespace
 
 FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src)
 {
@@ -122,6 +178,13 @@ void FrequencyDemod::rebuildPostLpf()
         if (len < 3) len = 3;
         std::vector<float> taps(len);
         liquid_firdes_kaiser(len, static_cast<float>(cutoff), atten, 0.0f, taps.data());
+        // liquid_firdes_kaiser returns un-normalised taps — sum diverges from
+        // 1.0 by a few % at typical lengths, so the Kaiser path used to
+        // produce a different magnitude than the IIRs. Renormalise to unity
+        // DC gain so the three filter methods are directly comparable.
+        double dc = 0.0;
+        for (auto t : taps) dc += t;
+        if (dc != 0.0) for (auto &t : taps) t = static_cast<float>(t / dc);
         postFir_ = firfilt_rrrf_create(taps.data(), len);
         // FIR is linear-phase; the impulse fully fits in `len` samples, so
         // the lead-in / cold-start window is just the tap count.
@@ -131,10 +194,14 @@ void FrequencyDemod::rebuildPostLpf()
     }
     case LpfMethod::ButterworthIir: {
         // Cheap maximally-flat IIR. ~36 dB/octave at order 6, no ripple.
-        // Settles much faster than elliptic for the same order because the
-        // step response has no equiripple tail.
+        // Built via the SOS prototype path: cascaded biquads stay
+        // numerically well-conditioned at low normalised cutoffs (a
+        // direct-form order-6 at fc/fs = 5e-4 is broken in float32 — the
+        // poles cluster at z=1 and the coefficients lose precision).
         const unsigned int order = 6;
-        postIir_ = iirfilt_rrrf_create_lowpass(order, static_cast<float>(cutoff));
+        postIir_ = iirfilt_rrrf_create_prototype(
+            LIQUID_IIRDES_BUTTER, LIQUID_IIRDES_LOWPASS, LIQUID_IIRDES_SOS,
+            order, static_cast<float>(cutoff), 0.0f, 0.1f, 60.0f);
         constexpr size_t kSettleCap = 500000;
         double settle = 2.0 * order / cutoff;
         if (settle > kSettleCap) settle = kSettleCap;
@@ -163,6 +230,13 @@ void FrequencyDemod::rebuildPostLpf()
         break;
     }
     }
+
+    FmLog::instance().writef(
+        "rebuildPostLpf: method=%s cutoffHz=%.3f Fs=%.0f cutoffNorm=%.6e "
+        "postLpfLen=%zu lpfSettle=%zu\n",
+        methodName(static_cast<int>(postLpfMethod_)),
+        postLpfCutoffHz_, postLpfBuiltAtRate_, cutoff,
+        postLpfLen_, lpfSettleSamples_);
 }
 
 void FrequencyDemod::applyPostLpf(float *out, int count)
@@ -257,8 +331,35 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
         if (!std::isfinite(out[i])) out[i] = 0.0f;
     }
 
+    // Stats just before the LPF — useful when comparing what each filter is
+    // fed against what it produces. Skip the per-sample scan unless the log
+    // is actually open (env var is set), so the hot path stays cheap.
+    double preMn = 0.0, preMx = 0.0;
+    if (FmLog::instance().enabled()) {
+        preMn = std::numeric_limits<double>::infinity();
+        preMx = -std::numeric_limits<double>::infinity();
+        for (int i = 0; i < count; ++i) {
+            if (out[i] < preMn) preMn = out[i];
+            if (out[i] > preMx) preMx = out[i];
+        }
+    }
+
     applyPostLpf(out, count);
     applyPostDecimation(out, count, sampleid);
+
+    // Stats after the LPF (still pre-NaN-mark) so we can see what the filter
+    // produced before the cold-start mask hides it.
+    double postMn = 0.0, postMx = 0.0;
+    size_t postNonFinite = 0;
+    if (FmLog::instance().enabled()) {
+        postMn = std::numeric_limits<double>::infinity();
+        postMx = -std::numeric_limits<double>::infinity();
+        for (int i = 0; i < count; ++i) {
+            if (!std::isfinite(out[i])) { ++postNonFinite; continue; }
+            if (out[i] < postMn) postMn = out[i];
+            if (out[i] > postMx) postMx = out[i];
+        }
+    }
 
     // Mark filter-warmup samples as NaN. The size of the warmup depends on
     // what's running:
@@ -274,6 +375,27 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
         for (size_t i = 0; i < bad; ++i) {
             out[i] = std::numeric_limits<float>::quiet_NaN();
         }
+    }
+
+    if (FmLog::instance().enabled()) {
+        size_t nans = 0;
+        double mn = std::numeric_limits<double>::infinity();
+        double mx = -std::numeric_limits<double>::infinity();
+        for (int i = 0; i < count; ++i) {
+            if (!std::isfinite(out[i])) { ++nans; continue; }
+            if (out[i] < mn) mn = out[i];
+            if (out[i] > mx) mx = out[i];
+        }
+        auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xffff;
+        FmLog::instance().writef(
+            "work tid=0x%04zx sampleid=%zu count=%d method=%s cutoffHz=%.3f "
+            "coldStart=%zu preMin=%.6g preMax=%.6g postMin=%.6g postMax=%.6g "
+            "postNonFinite=%zu finalNaN=%zu finalMin=%.6g finalMax=%.6g "
+            "cheap=%d\n",
+            tid, sampleid, count,
+            methodName(static_cast<int>(postLpfMethod_)), postLpfCutoffHz_,
+            coldStart, preMn, preMx, postMn, postMx,
+            postNonFinite, nans, mn, mx, cheapMode_ ? 1 : 0);
     }
 
 #if INSPECTRUM_FM_DEBUG

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -115,6 +115,23 @@ size_t FrequencyDemod::historySize()
     return base;
 }
 
+void FrequencyDemod::invalidateBatchCache()
+{
+    QMutexLocker ml(&batchMutex_);
+    batchCache_.valid = false;
+    batchCache_.length = 0;
+    batchCache_.startSample = 0;
+    // Drop the buffer so we don't hang onto megabytes after a parameter
+    // change — the next request will repopulate.
+    std::vector<float>().swap(batchCache_.data);
+}
+
+void FrequencyDemod::invalidateEvent()
+{
+    invalidateBatchCache();
+    SampleBuffer::invalidateEvent();
+}
+
 void FrequencyDemod::setPostLpfCutoff(double hz)
 {
     if (hz < 0.0) hz = 0.0;
@@ -124,6 +141,7 @@ void FrequencyDemod::setPostLpfCutoff(double hz)
         postLpfCutoffHz_ = hz;
         rebuildPostLpf(); // assumes mutex held
     }
+    invalidateBatchCache();
     invalidate();
 }
 
@@ -135,6 +153,7 @@ void FrequencyDemod::setPostLpfMethod(LpfMethod m)
         postLpfMethod_ = m;
         rebuildPostLpf(); // assumes mutex held
     }
+    invalidateBatchCache();
     invalidate();
 }
 
@@ -146,6 +165,18 @@ void FrequencyDemod::setPostDecimation(int n)
         if (n == postDecim_) return;
         postDecim_ = n;
     }
+    invalidateBatchCache();
+    invalidate();
+}
+
+void FrequencyDemod::setCheapDemod(bool enabled)
+{
+    {
+        QMutexLocker ml(&mutex);
+        if (enabled == cheapMode_) return;
+        cheapMode_ = enabled;
+    }
+    invalidateBatchCache();
     invalidate();
 }
 
@@ -338,6 +369,202 @@ void FrequencyDemod::applyPostDecimation(float *out, int count, size_t sampleid)
         for (int j = clip_start; j < clip_end; ++j) out[j] = avg;
         i = clip_end;
     }
+}
+
+bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
+{
+    // Caller must hold batchMutex_. Builds (or rebuilds) the cache so that
+    // it covers [needStart, needEnd). Pulls a wider range than strictly
+    // requested so successive tile requests panning around the same view
+    // hit the cache cheaply, and so the filtfilt has plenty of margin on
+    // both sides for its forward and reverse passes to settle outside the
+    // visible region.
+    const size_t total = count();
+    if (needEnd > total) needEnd = total;
+    if (needStart >= needEnd) return false;
+
+    // Snapshot filter parameters (the main mutex protects these from setter
+    // changes; a setter that wins the race will also have called
+    // invalidateBatchCache() so a stale cache won't survive).
+    LpfMethod method;
+    double    cutoffHz;
+    double    fs;
+    size_t    settle;
+    bool      cheap;
+    {
+        QMutexLocker ml(&mutex);
+        method   = postLpfMethod_;
+        cutoffHz = postLpfCutoffHz_;
+        fs       = rate();
+        settle   = lpfSettleSamples_ ? lpfSettleSamples_ : 4096;
+        cheap    = cheapMode_;
+    }
+
+    // Aim for a generous batch: at least 4× the requested range, with
+    // settle-many samples of margin on each side, and never less than 1 M
+    // samples (so casual panning stays in cache). Capped so a 100 GB file
+    // doesn't try to allocate ridiculous amounts of memory.
+    constexpr size_t kMinBatch = 1'000'000;
+    constexpr size_t kMaxBatch = 8'000'000;
+    const size_t reqLen = needEnd - needStart;
+    size_t margin = std::max<size_t>(settle, 4096);
+    size_t want   = std::max(kMinBatch, reqLen + 2 * margin);
+    if (want > kMaxBatch) want = kMaxBatch;
+    size_t centre = needStart + reqLen / 2;
+    size_t half   = want / 2;
+    size_t start  = (centre > half) ? (centre - half) : 0;
+    size_t end    = std::min(start + want, total);
+    // If we hit the end of the file, slide the window left so we still have
+    // the requested range covered.
+    if (end - start < want && start > 0) {
+        size_t shift = std::min(start, want - (end - start));
+        start -= shift;
+    }
+    if (start > needStart) start = needStart;
+    if (end   < needEnd)   end   = needEnd;
+    const size_t batchLen = end - start;
+    if (batchLen == 0) return false;
+
+    // Pull raw IQ from the upstream tuner. This one big getSamples call
+    // does the upstream lead-in once (Kaiser FIR tuner cold-start), so the
+    // freqdem and post-LPF below see a continuous, fully-warmed input.
+    auto rawIq = src->getSamples(start, batchLen);
+    if (!rawIq) return false;
+
+    // Demod the whole batch with a single freqdem pass so its internal
+    // state tracks the signal continuously across what would otherwise be
+    // tile boundaries.
+    std::vector<float> demod(batchLen);
+    {
+        QMutexLocker ml(&mutex);
+        if (cheap) {
+            if (batchLen > 0) {
+                std::complex<float> prev = rawIq[0];
+                demod[0] = 0.0f;
+                for (size_t i = 1; i < batchLen; ++i) {
+                    demod[i] = std::arg(rawIq[i] * std::conj(prev));
+                    prev = rawIq[i];
+                }
+            }
+        } else {
+            freqdem_reset(fdem_);
+            for (size_t i = 0; i < batchLen; ++i) {
+                float dem;
+                freqdem_demodulate(
+                    fdem_,
+                    *reinterpret_cast<liquid_float_complex*>(&rawIq[i]),
+                    &dem);
+                demod[i] = dem;
+            }
+        }
+        // Scrub non-finite freqdem output before the LPF — recursive IIR
+        // state would propagate any NaN forever.
+        for (size_t i = 0; i < batchLen; ++i) {
+            if (!std::isfinite(demod[i])) demod[i] = 0.0f;
+        }
+
+        // LPF (filtfilt for IIR; one-pass for FIR — although this code
+        // path is only entered for IIR methods).
+        if (method == LpfMethod::KaiserFir) {
+            // For Kaiser the per-tile path is correct (FIR is composable);
+            // we only end up here if the caller bypassed that intentionally.
+            if (postFir_) {
+                firfilt_rrrf_reset(postFir_);
+                for (size_t i = 0; i < batchLen; ++i) {
+                    firfilt_rrrf_push(postFir_, demod[i]);
+                    firfilt_rrrf_execute(postFir_, &demod[i]);
+                }
+            }
+        } else if (postIir_) {
+            // Forward pass over the entire batch.
+            iirfilt_rrrf_reset(postIir_);
+            for (size_t i = 0; i < batchLen; ++i) {
+                iirfilt_rrrf_execute(postIir_, demod[i], &demod[i]);
+            }
+            // Constant-pad on the right with the last forward-output value
+            // so the reverse pass cold-start happens in a benign region
+            // and settles to the same DC the data ends at.
+            const size_t pad = std::min<size_t>(settle, batchLen);
+            std::vector<float> tail(pad, demod.empty() ? 0.0f : demod.back());
+            // Reverse pass: pad first, then data, in reverse time order.
+            iirfilt_rrrf_reset(postIir_);
+            for (size_t i = 0; i < pad; ++i) {
+                float dummy;
+                iirfilt_rrrf_execute(postIir_, tail[i], &dummy);
+            }
+            for (size_t i = 0; i < batchLen; ++i) {
+                const size_t j = batchLen - 1 - i;
+                iirfilt_rrrf_execute(postIir_, demod[j], &demod[j]);
+            }
+        }
+
+        // Cold-start NaN mask: the file's first lpfSettleSamples_ are
+        // forward-pass transient and shouldn't bias the auto-scaling scan.
+        // Apply it in absolute (file-relative) coordinates so the same
+        // samples are masked regardless of which batch contains them.
+        const size_t coldStart = std::max<size_t>(512, settle);
+        if (start < coldStart) {
+            const size_t bad = std::min(coldStart - start, batchLen);
+            for (size_t i = 0; i < bad; ++i) {
+                demod[i] = std::numeric_limits<float>::quiet_NaN();
+            }
+        }
+    }
+
+    batchCache_.startSample = start;
+    batchCache_.length      = batchLen;
+    batchCache_.data        = std::move(demod);
+    batchCache_.valid       = true;
+    batchCache_.method      = method;
+    batchCache_.cutoffHz    = cutoffHz;
+    batchCache_.rate        = fs;
+    batchCache_.cheap       = cheap;
+
+    FmLog::instance().writef(
+        "fillBatchCache: method=%s cutoffHz=%.3f start=%zu len=%zu (covering "
+        "request [%zu, %zu))\n",
+        methodName(static_cast<int>(method)), cutoffHz, start, batchLen,
+        needStart, needEnd);
+    return true;
+}
+
+std::unique_ptr<float[]> FrequencyDemod::getSamples(size_t start, size_t length)
+{
+    // Snapshot the current method under the main mutex so we can decide
+    // which path to take without holding it through the slow filter run.
+    LpfMethod method;
+    double    cutoffHz;
+    {
+        QMutexLocker ml(&mutex);
+        method   = postLpfMethod_;
+        cutoffHz = postLpfCutoffHz_;
+    }
+
+    // Kaiser FIR (or "no LPF" / cheap mode without LPF) is composable
+    // across tile boundaries — fall through to the standard SampleBuffer
+    // pattern, which has the parallel-friendly per-tile work() path.
+    if (method == LpfMethod::KaiserFir || cutoffHz <= 0.0) {
+        return SampleBuffer::getSamples(start, length);
+    }
+
+    // IIR backends: serve from the batch cache so all tiles in the same
+    // view slice from a single continuous filtfilt pass.
+    QMutexLocker ml(&batchMutex_);
+    const bool covers = batchCache_.valid &&
+                        batchCache_.method   == method &&
+                        batchCache_.cutoffHz == cutoffHz &&
+                        start >= batchCache_.startSample &&
+                        (start + length) <=
+                            (batchCache_.startSample + batchCache_.length);
+    if (!covers) {
+        if (!fillBatchCache(start, start + length)) return nullptr;
+    }
+
+    auto result = std::make_unique<float[]>(length);
+    const size_t offset = start - batchCache_.startSample;
+    std::memcpy(result.get(), batchCache_.data.data() + offset,
+                length * sizeof(float));
+    return result;
 }
 
 void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -569,6 +569,21 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
         demod.assign(batchLen, 0.0f);
     }
 
+    // Small absolute file-start NaN mask for the upstream tuner's FIR
+    // cold-start. The bilateral pad above handles *our* LPF, but the
+    // tuner runs at full Fs upstream and its output samples [0..tuner_taps]
+    // are transient — feeding the freqdem garbage at file start, which we
+    // see as a one-time spike that dominates the autoscale. 4096 samples
+    // (≈ 400 µs at 10 MHz) covers the tuner FIR for any reasonable width
+    // and is small enough to not be visually noticeable.
+    constexpr size_t kFileStartMask = 4096;
+    if (start < kFileStartMask) {
+        const size_t bad = std::min(kFileStartMask - start, batchLen);
+        for (size_t i = 0; i < bad; ++i) {
+            demod[i] = std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+
     batchCache_.startSample = start;
     batchCache_.length      = batchLen;
     batchCache_.data        = std::move(demod);

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -46,7 +46,7 @@ FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>
 
 FrequencyDemod::~FrequencyDemod()
 {
-    if (postLpf_) iirfilt_rrrf_destroy(postLpf_);
+    destroyPostLpf();
     freqdem_destroy(fdem_);
 }
 
@@ -70,6 +70,17 @@ void FrequencyDemod::setPostLpfCutoff(double hz)
     invalidate();
 }
 
+void FrequencyDemod::setPostLpfMethod(LpfMethod m)
+{
+    {
+        QMutexLocker ml(&mutex);
+        if (m == postLpfMethod_) return;
+        postLpfMethod_ = m;
+        rebuildPostLpf(); // assumes mutex held
+    }
+    invalidate();
+}
+
 void FrequencyDemod::setPostDecimation(int n)
 {
     if (n < 1) n = 1;
@@ -81,61 +92,95 @@ void FrequencyDemod::setPostDecimation(int n)
     invalidate();
 }
 
+void FrequencyDemod::destroyPostLpf()
+{
+    if (postFir_) { firfilt_rrrf_destroy(postFir_); postFir_ = nullptr; }
+    if (postIir_) { iirfilt_rrrf_destroy(postIir_); postIir_ = nullptr; }
+    postLpfLen_ = 0;
+    lpfSettleSamples_ = 0;
+}
+
 void FrequencyDemod::rebuildPostLpf()
 {
-    if (postLpf_) {
-        iirfilt_rrrf_destroy(postLpf_);
-        postLpf_ = nullptr;
-        postLpfLen_ = 0;
-        lpfSettleSamples_ = 0;
-    }
+    destroyPostLpf();
     postLpfBuiltAtRate_ = rate();
     if (postLpfCutoffHz_ <= 0.0 || postLpfBuiltAtRate_ <= 0.0) return;
 
-    // Normalized cutoff (Fs = 1). Clamp away from 0 and 0.5 to keep the
-    // Butterworth design well-conditioned.
+    // Normalized cutoff (Fs = 1). Clamp away from 0 and 0.5 so every
+    // backend's design path stays well-conditioned.
     double cutoff = postLpfCutoffHz_ / postLpfBuiltAtRate_;
     if (cutoff >= 0.499) cutoff = 0.499;
     if (cutoff <= 1e-6)  cutoff = 1e-6;
 
-    // Elliptic IIR (cascaded SOS): closest IIR shape to a Kaiser FIR's brick
-    // wall — sharp transition with bounded passband / stopband ripple. Order
-    // 8 gives a transition width comparable to a long Kaiser FIR at a tiny
-    // fraction of the per-sample cost. SOS formatting keeps coefficients
-    // numerically well-conditioned at low normalized cutoffs.
-    const unsigned int order = 8;
-    const float Ap = 0.1f;   // passband ripple (dB)
-    const float As = 60.0f;  // stopband attenuation (dB)
-    postLpf_ = iirfilt_rrrf_create_prototype(
-        LIQUID_IIRDES_ELLIP, LIQUID_IIRDES_LOWPASS, LIQUID_IIRDES_SOS,
-        order, static_cast<float>(cutoff), 0.0f, Ap, As);
-
-    // Step-response settling for an Nth-order IIR lowpass scales as
-    // ~1.6·N / cutoff_norm samples to reach ~60 dB below peak ringing.
-    // Elliptic equiripple stopband can keep ringing past this nominal time,
-    // so add a 2× safety factor — the cold-start NaN window has to fully
-    // cover the transient or the auto-scaling y-axis chases the residual
-    // overshoot peaks at the start of the visible range. Cap the result so
-    // sub-Hz cutoffs don't try to allocate gigabytes of upstream lead-in.
-    constexpr size_t kSettleCap = 500000;
-    double settle = 3.2 * order / cutoff;
-    if (settle > kSettleCap) settle = kSettleCap;
-    lpfSettleSamples_ = static_cast<size_t>(settle);
-    // postLpfLen_ feeds into historySize() so SampleBuffer fetches enough
-    // upstream lead-in to consume the IIR transient before the returned
-    // output begins.
-    postLpfLen_ = lpfSettleSamples_;
+    switch (postLpfMethod_) {
+    case LpfMethod::KaiserFir: {
+        // Reference linear-phase FIR. Tap count from liquid's estimator at
+        // 60 dB stopband — this can be tens of thousands of taps for narrow
+        // cutoffs (slow, but the most accurate option).
+        const float atten = 60.0f;
+        unsigned int len = estimate_req_filter_len(std::max(cutoff, 1e-4), atten);
+        if (len < 3) len = 3;
+        std::vector<float> taps(len);
+        liquid_firdes_kaiser(len, static_cast<float>(cutoff), atten, 0.0f, taps.data());
+        postFir_ = firfilt_rrrf_create(taps.data(), len);
+        // FIR is linear-phase; the impulse fully fits in `len` samples, so
+        // the lead-in / cold-start window is just the tap count.
+        postLpfLen_ = len;
+        lpfSettleSamples_ = len;
+        break;
+    }
+    case LpfMethod::ButterworthIir: {
+        // Cheap maximally-flat IIR. ~36 dB/octave at order 6, no ripple.
+        // Settles much faster than elliptic for the same order because the
+        // step response has no equiripple tail.
+        const unsigned int order = 6;
+        postIir_ = iirfilt_rrrf_create_lowpass(order, static_cast<float>(cutoff));
+        constexpr size_t kSettleCap = 500000;
+        double settle = 2.0 * order / cutoff;
+        if (settle > kSettleCap) settle = kSettleCap;
+        lpfSettleSamples_ = static_cast<size_t>(settle);
+        postLpfLen_ = lpfSettleSamples_;
+        break;
+    }
+    case LpfMethod::EllipticIir: {
+        // Sharpest IIR transition for the order, at the cost of equiripple
+        // passband / stopband. Cascaded SOS keeps coefficients numerically
+        // well-conditioned at low normalized cutoffs.
+        const unsigned int order = 8;
+        const float Ap = 0.1f;   // passband ripple (dB)
+        const float As = 60.0f;  // stopband attenuation (dB)
+        postIir_ = iirfilt_rrrf_create_prototype(
+            LIQUID_IIRDES_ELLIP, LIQUID_IIRDES_LOWPASS, LIQUID_IIRDES_SOS,
+            order, static_cast<float>(cutoff), 0.0f, Ap, As);
+        // Equiripple stopband leaves a slowly-decaying tail past the nominal
+        // 1.6·N/cutoff_norm; double it so the cold-start NaN window covers
+        // the actual ringing rather than chasing residual peaks.
+        constexpr size_t kSettleCap = 500000;
+        double settle = 3.2 * order / cutoff;
+        if (settle > kSettleCap) settle = kSettleCap;
+        lpfSettleSamples_ = static_cast<size_t>(settle);
+        postLpfLen_ = lpfSettleSamples_;
+        break;
+    }
+    }
 }
 
 void FrequencyDemod::applyPostLpf(float *out, int count)
 {
-    if (!postLpf_) return;
     // Reset state each call: getSamples ranges can be non-contiguous. The
-    // SampleBuffer lead-in re-warms the IIR within ~order samples, so the
-    // 64-sample historySize() leeway is plenty.
-    iirfilt_rrrf_reset(postLpf_);
-    for (int i = 0; i < count; ++i) {
-        iirfilt_rrrf_execute(postLpf_, out[i], &out[i]);
+    // SampleBuffer lead-in (sized via postLpfLen_) re-warms the filter
+    // before the first returned sample.
+    if (postFir_) {
+        firfilt_rrrf_reset(postFir_);
+        for (int i = 0; i < count; ++i) {
+            firfilt_rrrf_push(postFir_, out[i]);
+            firfilt_rrrf_execute(postFir_, &out[i]);
+        }
+    } else if (postIir_) {
+        iirfilt_rrrf_reset(postIir_);
+        for (int i = 0; i < count; ++i) {
+            iirfilt_rrrf_execute(postIir_, out[i], &out[i]);
+        }
     }
 }
 
@@ -171,7 +216,8 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
     // Lazy build of the post-demod LPF: the upstream sample rate is often not
     // set at construction time (file opens after the chain is built), so the
     // filter is rebuilt here whenever Fs changes and a cutoff is configured.
-    if (postLpfCutoffHz_ > 0.0 && (!postLpf_ || postLpfBuiltAtRate_ != rate())) {
+    const bool haveLpf = (postFir_ || postIir_);
+    if (postLpfCutoffHz_ > 0.0 && (!haveLpf || postLpfBuiltAtRate_ != rate())) {
         rebuildPostLpf();
     }
 

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -33,8 +33,15 @@
 
 FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src)
 {
-    fdemBuiltAtBandwidth_ = relativeBandwidth();
-    fdem_ = freqdem_create(fdemBuiltAtBandwidth_ / 2.0);
+    // Use a fixed wide modulation factor (kf ≈ 0.49). This makes freqdem's
+    // output scale invariant to the tuner bandwidth — narrowing or widening
+    // the tuner now changes the *content* the demod sees but not the units of
+    // its output, so the plot's y-axis stays calibrated and doesn't jump
+    // wildly when the user drags the tuner cursors. The trade-off is reduced
+    // dynamic range for very narrow signals (output values are smaller than
+    // they'd be with a tightly-matched kf), but the plot auto-scales anyway.
+    fdemBuiltAtBandwidth_ = 1.0f;
+    fdem_ = freqdem_create(0.49f);
 }
 
 FrequencyDemod::~FrequencyDemod()
@@ -166,19 +173,7 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
         rebuildPostLpf();
     }
 
-    // Rebuild freqdem when the upstream tuner bandwidth changes. freqdem's
-    // modulation factor (kf) sets its output scale (output ≈ Δφ / (2π·kf));
-    // if kf doesn't track the actual signal bandwidth, output magnitudes
-    // jump dramatically every time the user resizes the tuner, which then
-    // also changes the IIR's transient overshoot and the auto-scaled y-axis.
-    {
-        float curBw = relativeBandwidth();
-        if (curBw != fdemBuiltAtBandwidth_) {
-            freqdem_destroy(fdem_);
-            fdemBuiltAtBandwidth_ = curBw;
-            fdem_ = freqdem_create(curBw / 2.0);
-        }
-    }
+    // (freqdem's kf is held fixed at construction — see comment in the ctor.)
 
     if (!cheapMode_) {
         // The demod is stateful and the same object is reused across all

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -29,7 +29,7 @@
 
 // Toggle in one place — prints from the demod hot-path are noisy, so leave
 // these off by default and flip to 1 when chasing a regression.
-#define INSPECTRUM_FM_DEBUG 1
+#define INSPECTRUM_FM_DEBUG 0
 
 FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src)
 {
@@ -39,7 +39,7 @@ FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>
 
 FrequencyDemod::~FrequencyDemod()
 {
-    if (postLpf_) firfilt_rrrf_destroy(postLpf_);
+    if (postLpf_) iirfilt_rrrf_destroy(postLpf_);
     freqdem_destroy(fdem_);
 }
 
@@ -77,38 +77,39 @@ void FrequencyDemod::setPostDecimation(int n)
 void FrequencyDemod::rebuildPostLpf()
 {
     if (postLpf_) {
-        firfilt_rrrf_destroy(postLpf_);
+        iirfilt_rrrf_destroy(postLpf_);
         postLpf_ = nullptr;
         postLpfLen_ = 0;
     }
     postLpfBuiltAtRate_ = rate();
     if (postLpfCutoffHz_ <= 0.0 || postLpfBuiltAtRate_ <= 0.0) return;
 
-    // liquid_firdes_kaiser takes normalized cutoff (Fs=1).
+    // Normalized cutoff (Fs = 1). Clamp away from 0 and 0.5 to keep the
+    // Butterworth design well-conditioned.
     double cutoff = postLpfCutoffHz_ / postLpfBuiltAtRate_;
-    if (cutoff >= 0.5) cutoff = 0.49;   // can't cut above Nyquist
-    const float atten = 60.0f;
-    // estimate_req_filter_len uses the transition bandwidth; use the cutoff
-    // itself as a conservative proxy (also clamp for very narrow cutoffs so
-    // filter length doesn't explode).
-    unsigned int len = estimate_req_filter_len(std::max(cutoff, 1e-4), atten);
-    if (len < 3) len = 3;
-    std::vector<float> taps(len);
-    liquid_firdes_kaiser(len, (float)cutoff, atten, 0.0f, taps.data());
-    postLpf_ = firfilt_rrrf_create(taps.data(), len);
-    postLpfLen_ = len;
+    if (cutoff >= 0.499) cutoff = 0.499;
+    if (cutoff <= 1e-6)  cutoff = 1e-6;
+
+    // 6th-order Butterworth: ~36 dB/octave rolloff and ~6-tap impulse decay.
+    // Far cheaper than a Kaiser FIR (which needs thousands of taps for the
+    // same cutoff) and the non-linear phase doesn't matter for visualization.
+    const unsigned int order = 6;
+    postLpf_ = iirfilt_rrrf_create_lowpass(order, static_cast<float>(cutoff));
+    // Used for SampleBuffer lead-in sizing. IIR settles much faster than the
+    // old FIR; a small constant comfortably covers the impulse response of
+    // typical orders (≤ ~12).
+    postLpfLen_ = 64;
 }
 
 void FrequencyDemod::applyPostLpf(float *out, int count)
 {
     if (!postLpf_) return;
     // Reset state each call: getSamples ranges can be non-contiguous. The
-    // SampleBuffer lead-in (historySize() covers the filter length) re-warms
-    // the FIR before the first returned sample.
-    firfilt_rrrf_reset(postLpf_);
+    // SampleBuffer lead-in re-warms the IIR within ~order samples, so the
+    // 64-sample historySize() leeway is plenty.
+    iirfilt_rrrf_reset(postLpf_);
     for (int i = 0; i < count; ++i) {
-        firfilt_rrrf_push(postLpf_, out[i]);
-        firfilt_rrrf_execute(postLpf_, &out[i]);
+        iirfilt_rrrf_execute(postLpf_, out[i], &out[i]);
     }
 }
 

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -91,11 +91,17 @@ void FrequencyDemod::rebuildPostLpf()
     if (cutoff >= 0.499) cutoff = 0.499;
     if (cutoff <= 1e-6)  cutoff = 1e-6;
 
-    // 6th-order Butterworth: ~36 dB/octave rolloff and ~6-tap impulse decay.
-    // Far cheaper than a Kaiser FIR (which needs thousands of taps for the
-    // same cutoff) and the non-linear phase doesn't matter for visualization.
-    const unsigned int order = 6;
-    postLpf_ = iirfilt_rrrf_create_lowpass(order, static_cast<float>(cutoff));
+    // Elliptic IIR (cascaded SOS): closest IIR shape to a Kaiser FIR's brick
+    // wall — sharp transition with bounded passband / stopband ripple. Order
+    // 8 gives a transition width comparable to a long Kaiser FIR at a tiny
+    // fraction of the per-sample cost. SOS formatting keeps coefficients
+    // numerically well-conditioned at low normalized cutoffs.
+    const unsigned int order = 8;
+    const float Ap = 0.1f;   // passband ripple (dB)
+    const float As = 60.0f;  // stopband attenuation (dB)
+    postLpf_ = iirfilt_rrrf_create_prototype(
+        LIQUID_IIRDES_ELLIP, LIQUID_IIRDES_LOWPASS, LIQUID_IIRDES_SOS,
+        order, static_cast<float>(cutoff), 0.0f, Ap, As);
 
     // Step-response settling time for a Butterworth lowpass scales like
     // 1/cutoff_norm. Empirically ~4 / cutoff_norm samples gets us well past

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -117,13 +117,17 @@ size_t FrequencyDemod::historySize()
 
 void FrequencyDemod::invalidateBatchCache()
 {
-    QMutexLocker ml(&batchMutex_);
-    batchCache_.valid = false;
-    batchCache_.length = 0;
-    batchCache_.startSample = 0;
-    // Drop the buffer so we don't hang onto megabytes after a parameter
-    // change — the next request will repopulate.
-    std::vector<float>().swap(batchCache_.data);
+    // Non-blocking: bump the cache epoch atomically. Any in-flight
+    // fillBatchCache() snapshotted the previous epoch at entry and will
+    // commit under it; getSamples's covers check rejects results tagged
+    // with an older epoch, so the next request triggers a fresh fill.
+    //
+    // Previously this took batchMutex_ to clear the cache fields, which
+    // meant every tuner drag (which fans into invalidateEvent → here)
+    // blocked on the worker's mutex for the full duration of fillBatchCache
+    // — visible in the latency trace as 100+ ms tunerMoved hangs. The old
+    // batch buffer lingers until the next fill replaces it; that's fine.
+    cacheEpoch_.fetch_add(1, std::memory_order_release);
 }
 
 void FrequencyDemod::invalidateEvent()
@@ -369,6 +373,14 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
     // hit the cache cheaply, and so the filtfilt has plenty of margin on
     // both sides for its forward and reverse passes to settle outside the
     // visible region.
+    //
+    // Snapshot the epoch at entry: if a non-blocking invalidate fires while
+    // we're computing, our committed result will carry the stale epoch and
+    // be rejected by the next getSamples covers check. The fill still runs
+    // to completion (we don't try to abort) — the wasted compute is the
+    // cost of letting invalidate skip the mutex wait.
+    const uint64_t fillEpoch = cacheEpoch_.load(std::memory_order_acquire);
+
     const size_t total = count();
     if (needEnd > total) needEnd = total;
     if (needStart >= needEnd) return false;
@@ -574,8 +586,9 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
     // this at the source means the plot's Y-axis labels read in Hz and
     // the hover value just appends "Hz" — no double-conversion anywhere.
     // Cheap mode (phase-diff path) gives `arg` per sample which is
-    // already 2π·f/Fs, so its Hz scale is Fs/(2π) instead.
-    {
+    // already 2π·f/Fs, so its Hz scale is Fs/(2π) instead. Skip when fs=0
+    // (sample rate not yet set / bogus settings) so the trace isn't zeroed.
+    if (fs > 0.0) {
         const double scale = cheap
             ? (fs / (2.0 * M_PI))
             : (0.49 * fs);
@@ -607,6 +620,7 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
     batchCache_.rate        = fs;
     batchCache_.cheap       = cheap;
     batchCache_.decim       = decim;
+    batchCache_.epoch       = fillEpoch;
 
     FmLog::instance().writef(
         "fillBatchCache: method=%s cutoffHz=%.3f decim=%d fsEff=%.0f "
@@ -646,7 +660,9 @@ std::unique_ptr<float[]> FrequencyDemod::getSamples(size_t start, size_t length)
     // a single continuous filtfilt (and a single decimator+demod when
     // pre-demod decimation is enabled).
     QMutexLocker ml(&batchMutex_);
+    const uint64_t nowEpoch = cacheEpoch_.load(std::memory_order_acquire);
     const bool covers = batchCache_.valid &&
+                        batchCache_.epoch    == nowEpoch &&
                         batchCache_.method   == method &&
                         batchCache_.cutoffHz == cutoffHz &&
                         batchCache_.decim    == decim &&
@@ -732,12 +748,22 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
     // Scale to instantaneous frequency in Hz (see fillBatchCache for the
     // matching scaling on the batched path). Y-axis labels and the hover
     // value both read in Hz from this point on.
+    //
+    // Guard: rate() can legitimately be 0 if the user opens a file without
+    // setting a sample rate (or with a bad SampleRate in QSettings). In that
+    // case, fall back to no scaling — the trace will show liquid's normalised
+    // m values in [-1, 1], which is exactly what the chain produced before
+    // the Hz-scaling commit. Multiplying by 0 here would zero the entire
+    // output and the user would see a flat-line FM trace with no clue why.
     {
-        const double scale = cheapMode_
-            ? (rate() / (2.0 * M_PI))
-            : (0.49 * rate());
-        const float scalef = static_cast<float>(scale);
-        for (int i = 0; i < count; ++i) out[i] *= scalef;
+        const double r = rate();
+        if (r > 0.0) {
+            const double scale = cheapMode_
+                ? (r / (2.0 * M_PI))
+                : (0.49 * r);
+            const float scalef = static_cast<float>(scale);
+            for (int i = 0; i < count; ++i) out[i] *= scalef;
+        }
     }
 
     // Stats after the LPF (still pre-NaN-mark) so we can see what the filter

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -19,11 +19,17 @@
 
 #include "frequencydemod.h"
 #include <liquid/liquid.h>
+#include <QDebug>
 #include <QMutexLocker>
 #include <cmath>
 #include <complex>
 #include <algorithm>
+#include <limits>
 #include <vector>
+
+// Toggle in one place — prints from the demod hot-path are noisy, so leave
+// these off by default and flip to 1 when chasing a regression.
+#define INSPECTRUM_FM_DEBUG 1
 
 FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src)
 {
@@ -171,12 +177,39 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
     applyPostLpf(out, count);
     applyPostDecimation(out, count, sampleid);
 
-    // Scrub non-finite values: freqdem's cold-start near sampleid=0 can
-    // produce NaN/Inf when the tuner's fresh FIR feeds it near-zero-magnitude
-    // samples, and NaN can then propagate through the rest of the chunk.
-    // Downstream (min/max scan, painter path) are finite-only, so replace
-    // any junk with zero.
-    for (int i = 0; i < count; ++i) {
-        if (!std::isfinite(out[i])) out[i] = 0.0f;
+    // Mark filter-warmup samples as NaN. SampleBuffer can only fetch
+    // min(start, historySize()) samples of lead-in, so when sampleid is small
+    // (the user is viewing near t=0) the upstream tuner FIR and freqdem are
+    // running from cold zero state and the first samples of work() output are
+    // filter transient — biased toward zero, not real FM. Explicit NaN means
+    // the existing isfinite() guards in the min/max scan and the painter path
+    // skip them rather than treating zeros as real data points and pulling
+    // globalMin/Max toward zero.
+    constexpr size_t COLD_START = 512;
+    if (sampleid < COLD_START) {
+        const size_t bad = std::min<size_t>(COLD_START - sampleid,
+                                            static_cast<size_t>(count));
+        for (size_t i = 0; i < bad; ++i) {
+            out[i] = std::numeric_limits<float>::quiet_NaN();
+        }
     }
+
+#if INSPECTRUM_FM_DEBUG
+    {
+        size_t nans = 0;
+        double mn = std::numeric_limits<double>::infinity();
+        double mx = -std::numeric_limits<double>::infinity();
+        for (int i = 0; i < count; ++i) {
+            if (!std::isfinite(out[i])) { ++nans; continue; }
+            if (out[i] < mn) mn = out[i];
+            if (out[i] > mx) mx = out[i];
+        }
+        qDebug().nospace() << "[FM] work sampleid=" << sampleid
+                           << " count=" << count
+                           << " nans=" << nans
+                           << " finite_min=" << mn
+                           << " finite_max=" << mx
+                           << " cheap=" << cheapMode_;
+    }
+#endif
 }

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -19,6 +19,7 @@
 
 #include "frequencydemod.h"
 #include <liquid/liquid.h>
+#include <QMutexLocker>
 #include <complex>
 #include <algorithm>
 #include <vector>
@@ -37,9 +38,7 @@ FrequencyDemod::~FrequencyDemod()
 
 size_t FrequencyDemod::historySize()
 {
-    // The post-demod LPF is run across (history + length) samples and reset at
-    // the start of each work() call, so the lead-in must cover the LPF taps or
-    // the first output samples are filter transient.
+    QMutexLocker ml(&mutex);
     size_t base = SampleBuffer::historySize();
     if (postLpfLen_ > base) base = postLpfLen_;
     return base;
@@ -48,17 +47,23 @@ size_t FrequencyDemod::historySize()
 void FrequencyDemod::setPostLpfCutoff(double hz)
 {
     if (hz < 0.0) hz = 0.0;
-    if (hz == postLpfCutoffHz_) return;
-    postLpfCutoffHz_ = hz;
-    rebuildPostLpf();
+    {
+        QMutexLocker ml(&mutex);
+        if (hz == postLpfCutoffHz_) return;
+        postLpfCutoffHz_ = hz;
+        rebuildPostLpf(); // assumes mutex held
+    }
     invalidate();
 }
 
 void FrequencyDemod::setPostDecimation(int n)
 {
     if (n < 1) n = 1;
-    if (n == postDecim_) return;
-    postDecim_ = n;
+    {
+        QMutexLocker ml(&mutex);
+        if (n == postDecim_) return;
+        postDecim_ = n;
+    }
     invalidate();
 }
 

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -20,6 +20,8 @@
 #include "frequencydemod.h"
 #include <liquid/liquid.h>
 #include <complex>
+#include <algorithm>
+#include <vector>
 
 FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src)
 {
@@ -29,14 +31,111 @@ FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>
 
 FrequencyDemod::~FrequencyDemod()
 {
-    // destroy the demodulator
+    if (postLpf_) firfilt_rrrf_destroy(postLpf_);
     freqdem_destroy(fdem_);
 }
 
-void FrequencyDemod::work(void *input, void *output, int count, size_t /*sampleid*/)
+size_t FrequencyDemod::historySize()
+{
+    // The post-demod LPF is run across (history + length) samples and reset at
+    // the start of each work() call, so the lead-in must cover the LPF taps or
+    // the first output samples are filter transient.
+    size_t base = SampleBuffer::historySize();
+    if (postLpfLen_ > base) base = postLpfLen_;
+    return base;
+}
+
+void FrequencyDemod::setPostLpfCutoff(double hz)
+{
+    if (hz < 0.0) hz = 0.0;
+    if (hz == postLpfCutoffHz_) return;
+    postLpfCutoffHz_ = hz;
+    rebuildPostLpf();
+    invalidate();
+}
+
+void FrequencyDemod::setPostDecimation(int n)
+{
+    if (n < 1) n = 1;
+    if (n == postDecim_) return;
+    postDecim_ = n;
+    invalidate();
+}
+
+void FrequencyDemod::rebuildPostLpf()
+{
+    if (postLpf_) {
+        firfilt_rrrf_destroy(postLpf_);
+        postLpf_ = nullptr;
+        postLpfLen_ = 0;
+    }
+    postLpfBuiltAtRate_ = rate();
+    if (postLpfCutoffHz_ <= 0.0 || postLpfBuiltAtRate_ <= 0.0) return;
+
+    // liquid_firdes_kaiser takes normalized cutoff (Fs=1).
+    double cutoff = postLpfCutoffHz_ / postLpfBuiltAtRate_;
+    if (cutoff >= 0.5) cutoff = 0.49;   // can't cut above Nyquist
+    const float atten = 60.0f;
+    // estimate_req_filter_len uses the transition bandwidth; use the cutoff
+    // itself as a conservative proxy (also clamp for very narrow cutoffs so
+    // filter length doesn't explode).
+    unsigned int len = estimate_req_filter_len(std::max(cutoff, 1e-4), atten);
+    if (len < 3) len = 3;
+    std::vector<float> taps(len);
+    liquid_firdes_kaiser(len, (float)cutoff, atten, 0.0f, taps.data());
+    postLpf_ = firfilt_rrrf_create(taps.data(), len);
+    postLpfLen_ = len;
+}
+
+void FrequencyDemod::applyPostLpf(float *out, int count)
+{
+    if (!postLpf_) return;
+    // Reset state each call: getSamples ranges can be non-contiguous. The
+    // SampleBuffer lead-in (historySize() covers the filter length) re-warms
+    // the FIR before the first returned sample.
+    firfilt_rrrf_reset(postLpf_);
+    for (int i = 0; i < count; ++i) {
+        firfilt_rrrf_push(postLpf_, out[i]);
+        firfilt_rrrf_execute(postLpf_, &out[i]);
+    }
+}
+
+void FrequencyDemod::applyPostDecimation(float *out, int count, size_t sampleid)
+{
+    if (postDecim_ <= 1) return;
+    const int N = postDecim_;
+    // Windows are aligned to absolute sample index (sampleid + i) so that
+    // successive getSamples() calls produce consistent values across call
+    // boundaries.
+    int i = 0;
+    while (i < count) {
+        const size_t abs_i = sampleid + static_cast<size_t>(i);
+        const size_t win_abs_start = (abs_i / N) * N;
+        int win_local_start = static_cast<int>(win_abs_start - sampleid);
+        int win_local_end = win_local_start + N;
+        int clip_start = std::max(0, win_local_start);
+        int clip_end = std::min(count, win_local_end);
+        if (clip_end <= clip_start) break;
+        double sum = 0.0;
+        for (int j = clip_start; j < clip_end; ++j) sum += out[j];
+        float avg = static_cast<float>(sum / (clip_end - clip_start));
+        for (int j = clip_start; j < clip_end; ++j) out[j] = avg;
+        i = clip_end;
+    }
+}
+
+void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
 {
     auto in  = static_cast<std::complex<float>*>(input);
     auto out = static_cast<float*>(output);
+
+    // Lazy build of the post-demod LPF: the upstream sample rate is often not
+    // set at construction time (file opens after the chain is built), so the
+    // filter is rebuilt here whenever Fs changes and a cutoff is configured.
+    if (postLpfCutoffHz_ > 0.0 && (!postLpf_ || postLpfBuiltAtRate_ != rate())) {
+        rebuildPostLpf();
+    }
+
     if (!cheapMode_) {
         // The demod is stateful and the same object is reused across all
         // getSamples() calls. Successive calls can be for non-contiguous
@@ -62,4 +161,7 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t /*samplei
             }
         }
     }
+
+    applyPostLpf(out, count);
+    applyPostDecimation(out, count, sampleid);
 }

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -33,8 +33,8 @@
 
 FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src)
 {
-    // create the demodulator once
-    fdem_ = freqdem_create(relativeBandwidth() / 2.0);
+    fdemBuiltAtBandwidth_ = relativeBandwidth();
+    fdem_ = freqdem_create(fdemBuiltAtBandwidth_ / 2.0);
 }
 
 FrequencyDemod::~FrequencyDemod()
@@ -158,6 +158,20 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
     // filter is rebuilt here whenever Fs changes and a cutoff is configured.
     if (postLpfCutoffHz_ > 0.0 && (!postLpf_ || postLpfBuiltAtRate_ != rate())) {
         rebuildPostLpf();
+    }
+
+    // Rebuild freqdem when the upstream tuner bandwidth changes. freqdem's
+    // modulation factor (kf) sets its output scale (output ≈ Δφ / (2π·kf));
+    // if kf doesn't track the actual signal bandwidth, output magnitudes
+    // jump dramatically every time the user resizes the tuner, which then
+    // also changes the IIR's transient overshoot and the auto-scaled y-axis.
+    {
+        float curBw = relativeBandwidth();
+        if (curBw != fdemBuiltAtBandwidth_) {
+            freqdem_destroy(fdem_);
+            fdemBuiltAtBandwidth_ = curBw;
+            fdem_ = freqdem_create(curBw / 2.0);
+        }
     }
 
     if (!cheapMode_) {

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -80,6 +80,7 @@ void FrequencyDemod::rebuildPostLpf()
         iirfilt_rrrf_destroy(postLpf_);
         postLpf_ = nullptr;
         postLpfLen_ = 0;
+        lpfSettleSamples_ = 0;
     }
     postLpfBuiltAtRate_ = rate();
     if (postLpfCutoffHz_ <= 0.0 || postLpfBuiltAtRate_ <= 0.0) return;
@@ -95,10 +96,20 @@ void FrequencyDemod::rebuildPostLpf()
     // same cutoff) and the non-linear phase doesn't matter for visualization.
     const unsigned int order = 6;
     postLpf_ = iirfilt_rrrf_create_lowpass(order, static_cast<float>(cutoff));
-    // Used for SampleBuffer lead-in sizing. IIR settles much faster than the
-    // old FIR; a small constant comfortably covers the impulse response of
-    // typical orders (≤ ~12).
-    postLpfLen_ = 64;
+
+    // Step-response settling time for a Butterworth lowpass scales like
+    // 1/cutoff_norm. Empirically ~4 / cutoff_norm samples gets us well past
+    // any visible overshoot ringing. Cap so a 1 Hz cutoff doesn't try to
+    // allocate gigabyte lead-ins; cap value chosen to keep history under
+    // ~1 MB of complex<float> upstream allocations.
+    constexpr size_t kSettleCap = 200000;
+    double settle = 4.0 / cutoff;
+    if (settle > kSettleCap) settle = kSettleCap;
+    lpfSettleSamples_ = static_cast<size_t>(settle);
+    // postLpfLen_ feeds into historySize() so SampleBuffer fetches enough
+    // upstream lead-in to consume the IIR transient before the returned
+    // output begins.
+    postLpfLen_ = lpfSettleSamples_;
 }
 
 void FrequencyDemod::applyPostLpf(float *out, int count)
@@ -175,20 +186,27 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
         }
     }
 
+    // Defensive scrub before the IIR: any non-finite freqdem sample (cold-
+    // start, or numerical edge case) would poison the IIR's recursive state
+    // and turn the entire rest of the chunk into NaN. Replace with zero so
+    // the IIR sees a well-behaved input and just transients from there.
+    for (int i = 0; i < count; ++i) {
+        if (!std::isfinite(out[i])) out[i] = 0.0f;
+    }
+
     applyPostLpf(out, count);
     applyPostDecimation(out, count, sampleid);
 
-    // Mark filter-warmup samples as NaN. SampleBuffer can only fetch
-    // min(start, historySize()) samples of lead-in, so when sampleid is small
-    // (the user is viewing near t=0) the upstream tuner FIR and freqdem are
-    // running from cold zero state and the first samples of work() output are
-    // filter transient — biased toward zero, not real FM. Explicit NaN means
-    // the existing isfinite() guards in the min/max scan and the painter path
-    // skip them rather than treating zeros as real data points and pulling
-    // globalMin/Max toward zero.
-    constexpr size_t COLD_START = 512;
-    if (sampleid < COLD_START) {
-        const size_t bad = std::min<size_t>(COLD_START - sampleid,
+    // Mark filter-warmup samples as NaN. The size of the warmup depends on
+    // what's running:
+    //   - tuner FIR transient (~256 samples)
+    //   - freqdem cold-start (~few samples)
+    //   - post-LPF IIR settle (~4/cutoff_norm samples — can be many thousands)
+    // The existing isfinite() guards in the scan and painter path then skip
+    // these so globalMin/Max isn't biased by IIR overshoot ringing.
+    const size_t coldStart = std::max<size_t>(512, lpfSettleSamples_);
+    if (sampleid < coldStart) {
+        const size_t bad = std::min<size_t>(coldStart - sampleid,
                                             static_cast<size_t>(count));
         for (size_t i = 0; i < bad; ++i) {
             out[i] = std::numeric_limits<float>::quiet_NaN();

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -444,16 +444,31 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
             if (out[i] < mn) mn = out[i];
             if (out[i] > mx) mx = out[i];
         }
+        // The kept/visible region is the last `count - postLpfLen_` samples;
+        // SampleBuffer discards the leading postLpfLen_ samples (the lead-in
+        // that warms up the filter). Compute stats just over that slice so
+        // we can tell whether transients live in the discarded lead-in
+        // (invisible) or leak into the visible plot.
+        const size_t lead = std::min(postLpfLen_, static_cast<size_t>(count));
+        size_t keptNan = 0;
+        double keptMn = std::numeric_limits<double>::infinity();
+        double keptMx = -std::numeric_limits<double>::infinity();
+        for (size_t i = lead; i < static_cast<size_t>(count); ++i) {
+            if (!std::isfinite(out[i])) { ++keptNan; continue; }
+            if (out[i] < keptMn) keptMn = out[i];
+            if (out[i] > keptMx) keptMx = out[i];
+        }
         auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xffff;
         FmLog::instance().writef(
             "work tid=0x%04zx sampleid=%zu count=%d method=%s cutoffHz=%.3f "
             "coldStart=%zu preMin=%.6g preMax=%.6g postMin=%.6g postMax=%.6g "
             "postNonFinite=%zu finalNaN=%zu finalMin=%.6g finalMax=%.6g "
-            "cheap=%d\n",
+            "keptLead=%zu keptNaN=%zu keptMin=%.6g keptMax=%.6g cheap=%d\n",
             tid, sampleid, count,
             methodName(static_cast<int>(postLpfMethod_)), postLpfCutoffHz_,
             coldStart, preMn, preMx, postMn, postMx,
-            postNonFinite, nans, mn, mx, cheapMode_ ? 1 : 0);
+            postNonFinite, nans, mn, mx,
+            lead, keptNan, keptMn, keptMx, cheapMode_ ? 1 : 0);
     }
 
 #if INSPECTRUM_FM_DEBUG

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -180,6 +180,18 @@ void FrequencyDemod::setCheapDemod(bool enabled)
     invalidate();
 }
 
+void FrequencyDemod::setPredemodDecimation(int m)
+{
+    if (m < 1) m = 1;
+    {
+        QMutexLocker ml(&mutex);
+        if (m == predemodDecim_) return;
+        predemodDecim_ = m;
+    }
+    invalidateBatchCache();
+    invalidate();
+}
+
 void FrequencyDemod::destroyPostLpf()
 {
     if (postFir_) { firfilt_rrrf_destroy(postFir_); postFir_ = nullptr; }
@@ -369,6 +381,7 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
     double    fs;
     size_t    settle;
     bool      cheap;
+    int       decim;
     {
         QMutexLocker ml(&mutex);
         method   = postLpfMethod_;
@@ -376,7 +389,9 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
         fs       = rate();
         settle   = lpfSettleSamples_ ? lpfSettleSamples_ : 4096;
         cheap    = cheapMode_;
+        decim    = predemodDecim_;
     }
+    if (decim < 1) decim = 1;
 
     // Aim for a generous batch: at least 4× the requested range, with
     // settle-many samples of margin on each side, and never less than 1 M
@@ -409,97 +424,149 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
     auto rawIq = src->getSamples(start, batchLen);
     if (!rawIq) return false;
 
-    // Demod the whole batch with a single freqdem pass so its internal
-    // state tracks the signal continuously across what would otherwise be
-    // tile boundaries.
-    std::vector<float> demod(batchLen);
+    // The chain runs at an "effective" sample rate fsEff = fs / decim. When
+    // decim == 1 this is just fs and the IQ buffer is used directly; when
+    // decim > 1 the IQ is first run through a polyphase multistage decimator
+    // so the freqdem and post-LPF operate at a rate where the user's cutoff
+    // (fc/fsEff) lands in the well-conditioned 0.01..0.1 range. After the
+    // LPF, hold-expand so the output buffer is still batchLen samples wide
+    // (one stretched value per decim input samples).
+    const double fsEff = fs / decim;
+    const std::complex<float> *iqEff = rawIq.get();
+    std::vector<std::complex<float>> decimIq;
+    size_t lenEff = batchLen;
+    if (decim > 1) {
+        // Liquid's multistage halfband resampler. rate = 1/M for decimation;
+        // 60 dB stopband is plenty for this visualisation use. Reset before
+        // each batch so the cache is deterministic.
+        msresamp_crcf rs = msresamp_crcf_create(1.0f / static_cast<float>(decim),
+                                                60.0f);
+        msresamp_crcf_reset(rs);
+        decimIq.resize(batchLen / static_cast<size_t>(decim) + 64);
+        unsigned int nOut = 0;
+        msresamp_crcf_execute(
+            rs,
+            reinterpret_cast<liquid_float_complex*>(rawIq.get()),
+            static_cast<unsigned int>(batchLen),
+            reinterpret_cast<liquid_float_complex*>(decimIq.data()),
+            &nOut);
+        msresamp_crcf_destroy(rs);
+        decimIq.resize(nOut);
+        iqEff = decimIq.data();
+        lenEff = nOut;
+    }
+
+    // Demod at the effective rate. The same freqdem object is reused — kf is
+    // fixed (see ctor), so it's invariant under sample rate, and reset at
+    // the start of every batch keeps state deterministic.
+    std::vector<float> demod(lenEff);
     {
         QMutexLocker ml(&mutex);
         if (cheap) {
-            if (batchLen > 0) {
-                std::complex<float> prev = rawIq[0];
+            if (lenEff > 0) {
+                std::complex<float> prev = iqEff[0];
                 demod[0] = 0.0f;
-                for (size_t i = 1; i < batchLen; ++i) {
-                    demod[i] = std::arg(rawIq[i] * std::conj(prev));
-                    prev = rawIq[i];
+                for (size_t i = 1; i < lenEff; ++i) {
+                    demod[i] = std::arg(iqEff[i] * std::conj(prev));
+                    prev = iqEff[i];
                 }
             }
         } else {
             freqdem_reset(fdem_);
-            for (size_t i = 0; i < batchLen; ++i) {
+            for (size_t i = 0; i < lenEff; ++i) {
                 float dem;
                 freqdem_demodulate(
                     fdem_,
-                    *reinterpret_cast<liquid_float_complex*>(&rawIq[i]),
+                    *reinterpret_cast<liquid_float_complex*>(
+                        const_cast<std::complex<float>*>(&iqEff[i])),
                     &dem);
                 demod[i] = dem;
             }
         }
-        // Scrub non-finite freqdem output before the LPF — recursive IIR
-        // state would propagate any NaN forever.
-        for (size_t i = 0; i < batchLen; ++i) {
+        for (size_t i = 0; i < lenEff; ++i) {
             if (!std::isfinite(demod[i])) demod[i] = 0.0f;
         }
 
-        // LPF (filtfilt for IIR; one-pass for FIR — although this code
-        // path is only entered for IIR methods).
-        if (method == LpfMethod::KaiserFir) {
-            // For Kaiser the per-tile path is correct (FIR is composable);
-            // we only end up here if the caller bypassed that intentionally.
-            if (postFir_) {
-                firfilt_rrrf_reset(postFir_);
-                for (size_t i = 0; i < batchLen; ++i) {
-                    firfilt_rrrf_push(postFir_, demod[i]);
-                    firfilt_rrrf_execute(postFir_, &demod[i]);
-                }
-            }
-        } else if (postIir_) {
-            // Filtfilt with bilateral constant padding. The forward pass
-            // cold-starts at the *start* of the buffer (state = 0); we pad
-            // the left with `first_sample` so the forward filter settles
-            // to that constant in the pad, then enters the data already
-            // matched at the boundary. The reverse pass cold-starts at the
-            // *end* of the buffer; we pad the right with the *forward
-            // pass*'s last output value (after running forward) so the
-            // reverse filter settles to that constant in its pad, then
-            // enters the data with the right initial conditions.
-            //
-            // Net result: the entire data region is fully settled for both
-            // passes — no NaN cold-start window needed at the start of the
-            // file, no boundary transients anywhere.
-            const size_t leftPad  = std::min<size_t>(settle, batchLen);
-            const size_t rightPad = std::min<size_t>(settle, batchLen);
-            std::vector<float> ext(leftPad + batchLen + rightPad);
-            const float first = batchLen > 0 ? demod[0] : 0.0f;
-            for (size_t i = 0; i < leftPad; ++i) ext[i] = first;
-            std::memcpy(ext.data() + leftPad, demod.data(),
-                        batchLen * sizeof(float));
-            // Right pad gets the data's last value before forward pass.
-            // The forward pass will smooth its output across the
-            // pad/data boundary; the *output* in the right pad ends up
-            // at whatever the filter settled to over the data, which is
-            // exactly what we want as the reverse pass's seed.
-            const float last = batchLen > 0 ? demod[batchLen - 1] : 0.0f;
-            for (size_t i = 0; i < rightPad; ++i) {
-                ext[leftPad + batchLen + i] = last;
-            }
+        // Build a fresh LPF for fsEff each call (cheap — designs a few
+        // hundred taps at most for Kaiser, or a small SOS cascade for IIR).
+        // Doing it locally rather than reusing the per-tile postFir_/postIir_
+        // avoids any rate-mismatch when the user toggles decim or cutoff.
+        if (cutoffHz > 0.0 && lenEff > 0) {
+            double cutoffNorm = cutoffHz / fsEff;
+            if (cutoffNorm >= 0.499) cutoffNorm = 0.499;
+            if (cutoffNorm <= 1e-6)  cutoffNorm = 1e-6;
 
-            iirfilt_rrrf_reset(postIir_);
-            for (size_t i = 0; i < ext.size(); ++i) {
-                iirfilt_rrrf_execute(postIir_, ext[i], &ext[i]);
+            if (method == LpfMethod::KaiserFir) {
+                constexpr unsigned int kMaxTaps = 4096;
+                const float atten = 60.0f;
+                unsigned int len = estimate_req_filter_len(
+                    std::max(cutoffNorm, 1e-4), atten);
+                if (len < 3) len = 3;
+                if (len > kMaxTaps) len = kMaxTaps;
+                if (len > lenEff) len = std::max<size_t>(lenEff, 3);
+                std::vector<float> taps(len);
+                liquid_firdes_kaiser(len, static_cast<float>(cutoffNorm),
+                                     atten, 0.0f, taps.data());
+                double dc = 0.0;
+                for (auto t : taps) dc += t;
+                if (dc != 0.0) for (auto &t : taps) t = static_cast<float>(t / dc);
+                firfilt_rrrf fir = firfilt_rrrf_create(taps.data(), len);
+                firfilt_rrrf_reset(fir);
+                for (size_t i = 0; i < lenEff; ++i) {
+                    firfilt_rrrf_push(fir, demod[i]);
+                    firfilt_rrrf_execute(fir, &demod[i]);
+                }
+                firfilt_rrrf_destroy(fir);
+            } else {
+                // Butterworth filtfilt with bilateral constant pad.
+                const unsigned int order = 6;
+                iirfilt_rrrf iir = iirfilt_rrrf_create_prototype(
+                    LIQUID_IIRDES_BUTTER, LIQUID_IIRDES_LOWPASS,
+                    LIQUID_IIRDES_SOS, order,
+                    static_cast<float>(cutoffNorm), 0.0f, 0.1f, 60.0f);
+                size_t lpfSettle = static_cast<size_t>(
+                    std::min<double>(2.0 * order / cutoffNorm, 50000.0));
+                if (lpfSettle > lenEff) lpfSettle = lenEff;
+                std::vector<float> ext(2 * lpfSettle + lenEff);
+                const float first = demod[0];
+                const float last  = demod[lenEff - 1];
+                for (size_t i = 0; i < lpfSettle; ++i) ext[i] = first;
+                std::memcpy(ext.data() + lpfSettle, demod.data(),
+                            lenEff * sizeof(float));
+                for (size_t i = 0; i < lpfSettle; ++i) {
+                    ext[lpfSettle + lenEff + i] = last;
+                }
+                iirfilt_rrrf_reset(iir);
+                for (size_t i = 0; i < ext.size(); ++i) {
+                    iirfilt_rrrf_execute(iir, ext[i], &ext[i]);
+                }
+                iirfilt_rrrf_reset(iir);
+                for (size_t i = 0; i < ext.size(); ++i) {
+                    const size_t j = ext.size() - 1 - i;
+                    iirfilt_rrrf_execute(iir, ext[j], &ext[j]);
+                }
+                std::memcpy(demod.data(), ext.data() + lpfSettle,
+                            lenEff * sizeof(float));
+                iirfilt_rrrf_destroy(iir);
             }
-            iirfilt_rrrf_reset(postIir_);
-            for (size_t i = 0; i < ext.size(); ++i) {
-                const size_t j = ext.size() - 1 - i;
-                iirfilt_rrrf_execute(postIir_, ext[j], &ext[j]);
-            }
-            // Copy back just the data portion — both pads are discarded.
-            std::memcpy(demod.data(), ext.data() + leftPad,
-                        batchLen * sizeof(float));
         }
-        // No cold-start NaN window in batched mode: the bilateral pad
-        // above means sample 0 of the file is just as settled as any
-        // other sample, so there's nothing to hide.
+    }
+
+    // Hold-expand to batchLen if we decimated. Each output sample of `demod`
+    // becomes `decim` consecutive samples of the cached buffer. Output rate
+    // stays at fs so downstream sample indexing is undisturbed.
+    std::vector<float> expanded;
+    if (decim > 1 && lenEff > 0) {
+        expanded.resize(batchLen);
+        for (size_t i = 0; i < batchLen; ++i) {
+            size_t srcIdx = i / static_cast<size_t>(decim);
+            if (srcIdx >= lenEff) srcIdx = lenEff - 1;
+            expanded[i] = demod[srcIdx];
+        }
+        demod = std::move(expanded);
+    } else if (decim > 1) {
+        // Empty batch → zeros (shouldn't happen given batchLen > 0).
+        demod.assign(batchLen, 0.0f);
     }
 
     batchCache_.startSample = start;
@@ -510,40 +577,50 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
     batchCache_.cutoffHz    = cutoffHz;
     batchCache_.rate        = fs;
     batchCache_.cheap       = cheap;
+    batchCache_.decim       = decim;
 
     FmLog::instance().writef(
-        "fillBatchCache: method=%s cutoffHz=%.3f start=%zu len=%zu (covering "
-        "request [%zu, %zu))\n",
-        methodName(static_cast<int>(method)), cutoffHz, start, batchLen,
+        "fillBatchCache: method=%s cutoffHz=%.3f decim=%d fsEff=%.0f "
+        "start=%zu len=%zu lenEff=%zu (covering request [%zu, %zu))\n",
+        methodName(static_cast<int>(method)), cutoffHz, decim, fsEff,
+        start, batchLen, lenEff,
         needStart, needEnd);
     return true;
 }
 
 std::unique_ptr<float[]> FrequencyDemod::getSamples(size_t start, size_t length)
 {
-    // Snapshot the current method under the main mutex so we can decide
-    // which path to take without holding it through the slow filter run.
+    // Snapshot under the main mutex so we can decide which path to take
+    // without holding it through the slow filter run.
     LpfMethod method;
     double    cutoffHz;
+    int       decim;
     {
         QMutexLocker ml(&mutex);
         method   = postLpfMethod_;
         cutoffHz = postLpfCutoffHz_;
+        decim    = predemodDecim_;
     }
 
-    // Kaiser FIR (or "no LPF" / cheap mode without LPF) is composable
-    // across tile boundaries — fall through to the standard SampleBuffer
-    // pattern, which has the parallel-friendly per-tile work() path.
-    if (method == LpfMethod::KaiserFir || cutoffHz <= 0.0) {
+    // Fall through to the per-tile SampleBuffer path only when (a) Kaiser
+    // FIR is selected (composable across tile boundaries → fine in
+    // parallel) OR there's no LPF, AND (b) pre-demod decimation is off.
+    // The decimated path always batches because the IQ has to be
+    // resampled in one go for the multistage halfband filter to be valid.
+    const bool canUsePerTile =
+        (method == LpfMethod::KaiserFir || cutoffHz <= 0.0) && decim <= 1;
+    if (canUsePerTile) {
         return SampleBuffer::getSamples(start, length);
     }
 
-    // IIR backends: serve from the batch cache so all tiles in the same
-    // view slice from a single continuous filtfilt pass.
+    // Serve from the batch cache so all tiles in the same view slice from
+    // a single continuous filtfilt (and a single decimator+demod when
+    // pre-demod decimation is enabled).
     QMutexLocker ml(&batchMutex_);
     const bool covers = batchCache_.valid &&
                         batchCache_.method   == method &&
                         batchCache_.cutoffHz == cutoffHz &&
+                        batchCache_.decim    == decim &&
                         start >= batchCache_.startSample &&
                         (start + length) <=
                             (batchCache_.startSample + batchCache_.length);

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -38,6 +38,11 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t /*samplei
     auto in  = static_cast<std::complex<float>*>(input);
     auto out = static_cast<float*>(output);
     if (!cheapMode_) {
+        // The demod is stateful and the same object is reused across all
+        // getSamples() calls. Successive calls can be for non-contiguous
+        // ranges (different tiles), so prior state is garbage. Reset here
+        // and rely on SampleBuffer's lead-in samples to re-warm the filter.
+        freqdem_reset(fdem_);
         // full FIR-based demod: run filter on every sample
         for (int i = 0; i < count; i++) {
             float dem;

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -210,8 +210,12 @@ void FrequencyDemod::rebuildPostLpf()
         postIir_ = iirfilt_rrrf_create_prototype(
             LIQUID_IIRDES_BUTTER, LIQUID_IIRDES_LOWPASS, LIQUID_IIRDES_SOS,
             order, static_cast<float>(cutoff), 0.0f, 0.1f, 60.0f);
+        // Filtfilt squares the magnitude response so stopband attenuation
+        // doubles in dB, which reduces overshoot and lets us shrink the
+        // settle budget vs single-pass. 1.0·N/cutoff_norm is empirically
+        // enough for Butterworth (no equiripple tail).
         constexpr size_t kSettleCap = 500000;
-        double settle = 2.0 * order / cutoff;
+        double settle = 1.0 * order / cutoff;
         if (settle > kSettleCap) settle = kSettleCap;
         lpfSettleSamples_ = static_cast<size_t>(settle);
         postLpfLen_ = lpfSettleSamples_;
@@ -227,11 +231,13 @@ void FrequencyDemod::rebuildPostLpf()
         postIir_ = iirfilt_rrrf_create_prototype(
             LIQUID_IIRDES_ELLIP, LIQUID_IIRDES_LOWPASS, LIQUID_IIRDES_SOS,
             order, static_cast<float>(cutoff), 0.0f, Ap, As);
-        // Equiripple stopband leaves a slowly-decaying tail past the nominal
-        // 1.6·N/cutoff_norm; double it so the cold-start NaN window covers
-        // the actual ringing rather than chasing residual peaks.
+        // Filtfilt squares the magnitude response — the equiripple stopband
+        // ripple becomes ripple² (much smaller in linear scale). The earlier
+        // 3.2·N/cutoff_norm factor was sized for single-pass Elliptic where
+        // stopband residue rang for thousands of samples; with filtfilt the
+        // tail is much shorter, so 1.6·N/cutoff_norm is enough.
         constexpr size_t kSettleCap = 500000;
-        double settle = 3.2 * order / cutoff;
+        double settle = 1.6 * order / cutoff;
         if (settle > kSettleCap) settle = kSettleCap;
         lpfSettleSamples_ = static_cast<size_t>(settle);
         postLpfLen_ = lpfSettleSamples_;
@@ -268,28 +274,40 @@ void FrequencyDemod::applyPostLpf(float *out, int count)
     //
     // Forward pass uses the leading SampleBuffer history to warm up. Reverse
     // pass starts at the right-hand edge of the buffer and would corrupt the
-    // last lpfSettleSamples_ samples of every tile if run directly. Pad the
-    // right with edge-reflected samples (matches scipy.signal.filtfilt's
-    // default) so the reverse pass cold-start happens in the pad region and
-    // the real data is fully settled by the time it's reached.
+    // last lpfSettleSamples_ samples of every tile if run directly. The trick
+    // is to pad on the right so the reverse-pass cold-start happens in the
+    // pad region. Pad order matters here:
+    //
+    //   1) Forward pass over [data] → forward_out (smoothed; spikes already
+    //      attenuated by the LPF).
+    //   2) Pad with the LAST forward-output value held constant. Reverse pass
+    //      starts in this constant region; with a unity-DC-gain filter and
+    //      zero initial state it settles to that constant within
+    //      lpfSettleSamples_ samples, matches the data boundary exactly,
+    //      and continues into the data with no transient.
+    //
+    // (Earlier: odd-reflection of the raw freqdem output. That gave wild pad
+    //  values whenever a spike landed near the right edge — e.g. a sample at
+    //  1.02 next to data at 0.018 reflected to -0.99 — which made the reverse
+    //  pass start chasing a non-physical level and bias the visible region.)
     const int pad = std::min<int>(static_cast<int>(lpfSettleSamples_),
                                   std::max(count, 1));
     std::vector<float> buf(static_cast<size_t>(count) + pad);
     std::memcpy(buf.data(), out, count * sizeof(float));
-    if (pad > 0 && count > 0) {
-        // Odd reflection around the last sample: 2*last - x[count-2-i].
-        // Avoids introducing a step at the boundary that would itself ring.
-        const float last = out[count - 1];
-        for (int i = 0; i < pad; ++i) {
-            const int src = (count - 2 - i >= 0) ? (count - 2 - i) : 0;
-            buf[count + i] = 2.0f * last - out[src];
-        }
-    }
 
+    // Forward pass over the data portion only.
     iirfilt_rrrf_reset(postIir_);
-    for (size_t i = 0; i < buf.size(); ++i) {
+    for (int i = 0; i < count; ++i) {
         iirfilt_rrrf_execute(postIir_, buf[i], &buf[i]);
     }
+    // Constant pad with the last forward-output sample so the reverse-pass
+    // cold-start has a smooth, in-range value to settle to.
+    if (pad > 0 && count > 0) {
+        const float last = buf[count - 1];
+        for (int i = 0; i < pad; ++i) buf[count + i] = last;
+    }
+    // Reverse pass over [data | constant pad]. Cold-start happens in the pad
+    // region; by the time the pass reaches the data it's settled.
     iirfilt_rrrf_reset(postIir_);
     for (size_t i = 0; i < buf.size(); ++i) {
         const size_t j = buf.size() - 1 - i;

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -21,6 +21,8 @@
 #include <liquid/liquid.h>
 
 #include <QMutex>
+#include <atomic>
+#include <cstdint>
 #include <vector>
 
 #include "samplebuffer.h"
@@ -120,9 +122,15 @@ private:
         double       rate = 0.0;
         bool         cheap = false;
         int          decim = 1;
+        // Bumped by invalidateBatchCache() (non-blocking, atomic). A cache
+        // committed under an older epoch is rejected by getSamples's covers
+        // check — no need to take batchMutex_ to invalidate, which used to
+        // stall the GUI thread for the duration of any in-flight fill.
+        uint64_t     epoch = 0;
     };
-    QMutex      batchMutex_;
-    BatchCache  batchCache_;
+    QMutex                batchMutex_;
+    BatchCache            batchCache_;
+    std::atomic<uint64_t> cacheEpoch_{1};
     void invalidateBatchCache();
     bool fillBatchCache(size_t needStart, size_t needEnd);
 };

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -28,14 +28,30 @@ public:
     FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
     virtual ~FrequencyDemod();
     void work(void *input, void *output, int count, size_t sampleid) override;
+    size_t historySize() override;
+
+    // Toggle fast-path demodulation (instantaneous phase diff).
+    void setCheapDemod(bool enabled) { cheapMode_ = enabled; }
+    // Post-demod LPF cutoff in Hz. 0 disables the filter.
+    void setPostLpfCutoff(double hz);
+    // Block-averaging decimation on the post-demod stream. N=1 disables.
+    void setPostDecimation(int n);
+
 private:
     // Liquid-DSP frequency demodulator object
     freqdem      fdem_;
-    // if true, use fast instantaneous-frequency demod instead of full FIR
+    // Fast instantaneous-frequency demod (phase difference) instead of full FIR
     bool         cheapMode_ = false;
-public:
-    /**
-     * Toggle fast-path demodulation mode (instantaneous phase diff).
-     */
-    void setCheapDemod(bool enabled) { cheapMode_ = enabled; }
+    // Post-demod LPF (built lazily when the upstream sample rate is known)
+    double       postLpfCutoffHz_ = 0.0;
+    firfilt_rrrf postLpf_ = nullptr;
+    size_t       postLpfLen_ = 0;
+    // Cached sample rate used to build postLpf_; rebuilds when it changes.
+    double       postLpfBuiltAtRate_ = 0.0;
+    // Post-demod block-average decimation. 1 = disabled.
+    int          postDecim_ = 1;
+
+    void rebuildPostLpf();
+    void applyPostLpf(float *out, int count);
+    void applyPostDecimation(float *out, int count, size_t sampleid);
 };

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -28,14 +28,16 @@
 class FrequencyDemod : public SampleBuffer<std::complex<float>, float>
 {
 public:
-    // Available post-demod LPF implementations. KaiserFir is the original
-    // (linear-phase, accurate, but very slow at narrow cutoffs);
-    // ButterworthIir and EllipticIir are cheap-per-sample IIR alternatives.
-    // Kept selectable so the user can A/B against the reference.
+    // Available post-demod LPF implementations. KaiserFir is the
+    // linear-phase reference (accurate, slow at narrow cutoffs);
+    // ButterworthIir is a cheap-per-sample IIR run as filtfilt over a
+    // batched window for zero-phase response. (Elliptic was dropped:
+    // order-8 equiripple at fc/fs ≤ 1e-3 is numerically marginal in
+    // float32 and the long impulse autocorrelation through filtfilt
+    // produces visible ringing that no amount of padding hides.)
     enum class LpfMethod {
         KaiserFir = 0,
         ButterworthIir = 1,
-        EllipticIir = 2,
     };
 
     FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -62,7 +62,7 @@ private:
     // Two backends are supported — exactly one of postFir_/postIir_ is non-null
     // at a time depending on postLpfMethod_.
     double       postLpfCutoffHz_ = 0.0;
-    LpfMethod    postLpfMethod_ = LpfMethod::EllipticIir;
+    LpfMethod    postLpfMethod_ = LpfMethod::KaiserFir;
     firfilt_rrrf postFir_ = nullptr;
     iirfilt_rrrf postIir_ = nullptr;
     size_t       postLpfLen_ = 0;

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -20,6 +20,9 @@
 #pragma once
 #include <liquid/liquid.h>
 
+#include <QMutex>
+#include <vector>
+
 #include "samplebuffer.h"
 
 class FrequencyDemod : public SampleBuffer<std::complex<float>, float>
@@ -39,9 +42,18 @@ public:
     virtual ~FrequencyDemod();
     void work(void *input, void *output, int count, size_t sampleid) override;
     size_t historySize() override;
+    // Override SampleBuffer's per-tile getSamples so the IIR backends can
+    // run filtfilt over a *batched* range and serve sliced results from a
+    // cache. Filtfilt is non-composable across tile boundaries (each tile's
+    // independent forward+reverse pass picks up its own boundary conditions
+    // → visible step discontinuities at every seam) so per-tile filtfilt
+    // never produces a clean plot. Kaiser FIR is composable and falls
+    // through to the standard per-tile path unchanged.
+    std::unique_ptr<float[]> getSamples(size_t start, size_t length) override;
+    void invalidateEvent() override;
 
     // Toggle fast-path demodulation (instantaneous phase diff).
-    void setCheapDemod(bool enabled) { cheapMode_ = enabled; }
+    void setCheapDemod(bool enabled);
     // Post-demod LPF cutoff in Hz. 0 disables the filter.
     void setPostLpfCutoff(double hz);
     // Select which LPF implementation to use.
@@ -79,4 +91,26 @@ private:
     void rebuildPostLpf();
     void applyPostLpf(float *out, int count);
     void applyPostDecimation(float *out, int count, size_t sampleid);
+
+    // Batched-filter cache used by the IIR backends so that all tiles in a
+    // frame slice from the same single forward+reverse pass — the only way
+    // to make filtfilt produce a continuous result across tile boundaries.
+    // Guarded by batchMutex_; filter rebuild and freqdem state still go
+    // through the SampleBuffer base mutex.
+    struct BatchCache {
+        size_t       startSample = 0;
+        size_t       length = 0;
+        std::vector<float> data;
+        bool         valid = false;
+        // Snapshot the filter parameters used to populate this cache. Any
+        // change here invalidates the entry on the next access.
+        LpfMethod    method = LpfMethod::KaiserFir;
+        double       cutoffHz = 0.0;
+        double       rate = 0.0;
+        bool         cheap = false;
+    };
+    QMutex      batchMutex_;
+    BatchCache  batchCache_;
+    void invalidateBatchCache();
+    bool fillBatchCache(size_t needStart, size_t needEnd);
 };

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -62,6 +62,12 @@ public:
     void setPostLpfMethod(LpfMethod m);
     // Block-averaging decimation on the post-demod stream. N=1 disables.
     void setPostDecimation(int n);
+    // Pre-demod decimation factor (M). M=1 disables; M>1 routes the chain
+    // through a polyphase IQ decimator → freqdem at Fs/M → LPF at Fs/M →
+    // hold-expand back to Fs. This is the IQEngine pattern: doing the FM
+    // demod and post-LPF at a low rate keeps the post-LPF in a numerically
+    // well-conditioned regime and shrinks every filter's tap budget.
+    void setPredemodDecimation(int m);
 
 private:
     // Liquid-DSP frequency demodulator object
@@ -88,6 +94,9 @@ private:
     double       postLpfBuiltAtRate_ = 0.0;
     // Post-demod block-average decimation. 1 = disabled.
     int          postDecim_ = 1;
+    // Pre-demod IQ decimation factor (1 = disabled). When >1 the batched
+    // path runs the entire chain at Fs/M.
+    int          predemodDecim_ = 1;
 
     void destroyPostLpf();
     void rebuildPostLpf();
@@ -110,6 +119,7 @@ private:
         double       cutoffHz = 0.0;
         double       rate = 0.0;
         bool         cheap = false;
+        int          decim = 1;
     };
     QMutex      batchMutex_;
     BatchCache  batchCache_;

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -40,6 +40,10 @@ public:
 private:
     // Liquid-DSP frequency demodulator object
     freqdem      fdem_;
+    // Bandwidth used to create fdem_; rebuilt lazily in work() when the
+    // upstream tuner's relativeBandwidth() changes (e.g. user dragged the
+    // tuner cursors), so freqdem's modulation factor tracks the signal.
+    float        fdemBuiltAtBandwidth_ = -1.0f;
     // Fast instantaneous-frequency demod (phase difference) instead of full FIR
     bool         cheapMode_ = false;
     // Post-demod LPF (built lazily when the upstream sample rate is known).

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -42,9 +42,12 @@ private:
     freqdem      fdem_;
     // Fast instantaneous-frequency demod (phase difference) instead of full FIR
     bool         cheapMode_ = false;
-    // Post-demod LPF (built lazily when the upstream sample rate is known)
+    // Post-demod LPF (built lazily when the upstream sample rate is known).
+    // IIR Butterworth — fast at any cutoff, short impulse response (a few
+    // samples). Order 6 ≈ 36 dB/octave which is plenty for FM noise cleanup
+    // and avoids the huge tap count a Kaiser FIR would need at low Fc.
     double       postLpfCutoffHz_ = 0.0;
-    firfilt_rrrf postLpf_ = nullptr;
+    iirfilt_rrrf postLpf_ = nullptr;
     size_t       postLpfLen_ = 0;
     // Cached sample rate used to build postLpf_; rebuilds when it changes.
     double       postLpfBuiltAtRate_ = 0.0;

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -25,6 +25,16 @@
 class FrequencyDemod : public SampleBuffer<std::complex<float>, float>
 {
 public:
+    // Available post-demod LPF implementations. KaiserFir is the original
+    // (linear-phase, accurate, but very slow at narrow cutoffs);
+    // ButterworthIir and EllipticIir are cheap-per-sample IIR alternatives.
+    // Kept selectable so the user can A/B against the reference.
+    enum class LpfMethod {
+        KaiserFir = 0,
+        ButterworthIir = 1,
+        EllipticIir = 2,
+    };
+
     FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
     virtual ~FrequencyDemod();
     void work(void *input, void *output, int count, size_t sampleid) override;
@@ -34,6 +44,8 @@ public:
     void setCheapDemod(bool enabled) { cheapMode_ = enabled; }
     // Post-demod LPF cutoff in Hz. 0 disables the filter.
     void setPostLpfCutoff(double hz);
+    // Select which LPF implementation to use.
+    void setPostLpfMethod(LpfMethod m);
     // Block-averaging decimation on the post-demod stream. N=1 disables.
     void setPostDecimation(int n);
 
@@ -47,21 +59,23 @@ private:
     // Fast instantaneous-frequency demod (phase difference) instead of full FIR
     bool         cheapMode_ = false;
     // Post-demod LPF (built lazily when the upstream sample rate is known).
-    // IIR Butterworth — fast at any cutoff, short impulse response (a few
-    // samples). Order 6 ≈ 36 dB/octave which is plenty for FM noise cleanup
-    // and avoids the huge tap count a Kaiser FIR would need at low Fc.
+    // Two backends are supported — exactly one of postFir_/postIir_ is non-null
+    // at a time depending on postLpfMethod_.
     double       postLpfCutoffHz_ = 0.0;
-    iirfilt_rrrf postLpf_ = nullptr;
+    LpfMethod    postLpfMethod_ = LpfMethod::EllipticIir;
+    firfilt_rrrf postFir_ = nullptr;
+    iirfilt_rrrf postIir_ = nullptr;
     size_t       postLpfLen_ = 0;
-    // Number of samples the IIR needs to settle from a cold-start. Scales
-    // with 1/cutoff_norm (narrow filter → longer settle); used to size both
-    // SampleBuffer's history and the cold-start NaN-mark window.
+    // Number of samples the LPF needs to settle from a cold-start. For FIR
+    // this is the tap count; for IIR it scales with 1/cutoff_norm. Used to
+    // size both SampleBuffer's history and the cold-start NaN-mark window.
     size_t       lpfSettleSamples_ = 0;
-    // Cached sample rate used to build postLpf_; rebuilds when it changes.
+    // Cached sample rate used to build the LPF; rebuilds when it changes.
     double       postLpfBuiltAtRate_ = 0.0;
     // Post-demod block-average decimation. 1 = disabled.
     int          postDecim_ = 1;
 
+    void destroyPostLpf();
     void rebuildPostLpf();
     void applyPostLpf(float *out, int count);
     void applyPostDecimation(float *out, int count, size_t sampleid);

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -49,6 +49,10 @@ private:
     double       postLpfCutoffHz_ = 0.0;
     iirfilt_rrrf postLpf_ = nullptr;
     size_t       postLpfLen_ = 0;
+    // Number of samples the IIR needs to settle from a cold-start. Scales
+    // with 1/cutoff_norm (narrow filter → longer settle); used to size both
+    // SampleBuffer's history and the cold-start NaN-mark window.
+    size_t       lpfSettleSamples_ = 0;
     // Cached sample rate used to build postLpf_; rebuilds when it changes.
     double       postLpfBuiltAtRate_ = 0.0;
     // Post-demod block-average decimation. 1 = disabled.

--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -23,9 +23,11 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <stdexcept>
 #include <algorithm>
+#include <vector>
 
 #include <QFileInfo>
 
@@ -39,6 +41,7 @@
 #include <QJsonArray>
 #include <QFile>
 #include <QColor>
+#include <QXmlStreamReader>
 
 
 class ComplexF32SampleAdapter : public SampleAdapter {
@@ -220,6 +223,63 @@ public:
     }
 };
 
+namespace {
+
+// Rohde & Schwarz .iq.tar support: a USTAR archive that bundles a raw IQ
+// data file and an XML manifest. The manifest describes the format, sample
+// rate, center frequency, etc. We parse the tar in-place (it is already
+// mmap'd) so the sample-path reads can proceed at the data file's byte
+// offset with no extra copy.
+
+struct TarEntry {
+    QString name;
+    qint64 dataOffset;
+    qint64 size;
+};
+
+static qint64 tarOctal(const char *buf, size_t len)
+{
+    // Tar numeric fields are zero- or space-padded octal ASCII, usually
+    // null- or space-terminated. strtoll would choke on trailing junk, so
+    // copy into a local null-terminated buffer and parse there.
+    char tmp[32];
+    size_t n = std::min(len, sizeof(tmp) - 1);
+    memcpy(tmp, buf, n);
+    tmp[n] = 0;
+    return strtoll(tmp, nullptr, 8);
+}
+
+static std::vector<TarEntry> parseTar(const uchar *data, qint64 totalSize)
+{
+    std::vector<TarEntry> entries;
+    qint64 pos = 0;
+    while (pos + 512 <= totalSize) {
+        const char *hdr = reinterpret_cast<const char*>(data + pos);
+        bool allZero = true;
+        for (int i = 0; i < 512; ++i) { if (hdr[i]) { allZero = false; break; } }
+        if (allZero) break;
+
+        // Name: 100 bytes, null-terminated; use memchr to stay within the field
+        const char *nul = static_cast<const char*>(memchr(hdr, 0, 100));
+        int nameLen = nul ? static_cast<int>(nul - hdr) : 100;
+        QString name = QString::fromUtf8(hdr, nameLen);
+
+        qint64 sz = tarOctal(hdr + 124, 12);
+        char typeflag = hdr[156];
+
+        qint64 dataStart = pos + 512;
+        // Only regular files ('0' in ustar, '\0' in very old tar) carry data
+        // we care about; skip directories, links, etc.
+        if (typeflag == '0' || typeflag == '\0') {
+            entries.push_back({name, dataStart, sz});
+        }
+        pos = dataStart + ((sz + 511) / 512) * 512;
+    }
+    return entries;
+}
+
+} // namespace
+
 InputSource::InputSource()
 {
 }
@@ -364,11 +424,126 @@ QJsonObject InputSource::readMetaData(const QString &filename)
     return root;
 }
 
+void InputSource::openIqTar(const uchar *data, qint64 size)
+{
+    auto entries = parseTar(data, size);
+
+    const TarEntry *xmlEntry = nullptr;
+    for (const auto &e : entries) {
+        if (e.name.endsWith(".xml", Qt::CaseInsensitive)) { xmlEntry = &e; break; }
+    }
+    if (!xmlEntry)
+        throw std::runtime_error("iq.tar: no XML manifest found in archive");
+
+    QByteArray xmlBytes(reinterpret_cast<const char*>(data + xmlEntry->dataOffset),
+                        static_cast<int>(xmlEntry->size));
+    QXmlStreamReader xml(xmlBytes);
+
+    QString dataFilename, format, dataType;
+    int numChannels = 1;
+    double clock = 0.0;
+    double centerFreq = 0.0;
+    qint64 xmlSamples = 0;
+
+    while (!xml.atEnd() && !xml.hasError()) {
+        xml.readNext();
+        if (!xml.isStartElement()) continue;
+        auto name = xml.name().toString();
+        if      (name == "DataFilename")     dataFilename = xml.readElementText();
+        else if (name == "Clock")            clock = xml.readElementText().toDouble();
+        else if (name == "Samples")          xmlSamples = xml.readElementText().toLongLong();
+        else if (name == "Format")           format = xml.readElementText();
+        else if (name == "DataType")         dataType = xml.readElementText();
+        else if (name == "NumberOfChannels") numChannels = xml.readElementText().toInt();
+        else if (name == "CenterFrequency") {
+            bool ok;
+            double cf = xml.readElementText().toDouble(&ok);
+            if (ok) centerFreq = cf;
+        }
+    }
+    if (xml.hasError())
+        throw std::runtime_error(("iq.tar: XML parse error: " + xml.errorString()).toStdString());
+    if (dataFilename.isEmpty())
+        throw std::runtime_error("iq.tar: XML manifest is missing <DataFilename>");
+    if (numChannels != 1)
+        throw std::runtime_error("iq.tar: multi-channel archives are not supported");
+
+    const TarEntry *dataEntry = nullptr;
+    for (const auto &e : entries) {
+        if (e.name == dataFilename) { dataEntry = &e; break; }
+    }
+    if (!dataEntry)
+        throw std::runtime_error(("iq.tar: data file '" + dataFilename +
+                                  "' referenced by manifest not found in archive").toStdString());
+
+    const QString fmtL = format.toLower();
+    const QString dtL  = dataType.toLower();
+    _realSignal = false;
+    if (fmtL == "complex" && dtL == "float32") {
+        sampleAdapter = std::make_unique<ComplexF32SampleAdapter>();
+    } else if (fmtL == "complex" && dtL == "int32") {
+        sampleAdapter = std::make_unique<ComplexS32SampleAdapter>();
+    } else if (fmtL == "complex" && dtL == "int16") {
+        sampleAdapter = std::make_unique<ComplexS16SampleAdapter>();
+    } else if (fmtL == "real" && dtL == "float32") {
+        sampleAdapter = std::make_unique<RealF32SampleAdapter>();
+        _realSignal = true;
+    } else if (fmtL == "real" && dtL == "int16") {
+        sampleAdapter = std::make_unique<RealS16SampleAdapter>();
+        _realSignal = true;
+    } else {
+        throw std::runtime_error(("iq.tar: unsupported Format/DataType combination: " +
+                                  format + "/" + dataType).toStdString());
+    }
+
+    dataOffset = static_cast<size_t>(dataEntry->dataOffset);
+    size_t derivedCount = dataEntry->size / sampleAdapter->sampleSize();
+    // Trust the raw tar entry size over the XML Samples count: NumberOfPreSamples
+    // and NumberOfPostSamples (which we don't separate out here) can make the
+    // two disagree, and the entry size is what actually sits on disk.
+    sampleCount = derivedCount > 0 ? derivedCount : static_cast<size_t>(xmlSamples);
+    if (clock > 0.0) sampleRate = clock;
+    frequency = centerFreq;
+}
+
 void InputSource::openFile(const char *filename)
 {
     QFileInfo fileInfo(filename);
     std::string suffix = std::string(fileInfo.suffix().toLower().toUtf8().constData());
     if (_fmt != "") { suffix = _fmt; } // allow fmt override
+
+    // Default to no container offset; openIqTar overrides this for archives.
+    dataOffset = 0;
+
+    // R&S iq.tar container — delegate to openIqTar which discovers format,
+    // sample rate, center frequency, and the offset of the raw data file
+    // within the mmap'd archive.
+    if (_fmt.empty() && fileInfo.fileName().endsWith(".iq.tar", Qt::CaseInsensitive)) {
+        auto file = std::make_unique<QFile>(filename);
+        if (!file->open(QFile::ReadOnly)) {
+            throw std::runtime_error(file->errorString().toStdString());
+        }
+        qint64 size = file->size();
+        uchar *data = file->map(0, size);
+        if (data == nullptr)
+            throw std::runtime_error("Error mmapping iq.tar file");
+
+        annotationList.clear();
+        dataOffset = 0;
+        try {
+            openIqTar(data, size);
+        } catch (...) {
+            file->unmap(data);
+            throw;
+        }
+
+        cleanup();
+        inputFile = file.release();
+        mmapData = data;
+        invalidate();
+        return;
+    }
+
     if ((suffix == "cfile") || (suffix == "cf32")  || (suffix == "fc32")) {
         sampleAdapter = std::make_unique<ComplexF32SampleAdapter>();
     }
@@ -487,7 +662,7 @@ std::unique_ptr<std::complex<float>[]> InputSource::getSamples(size_t start, siz
         return nullptr;
 
     auto dest = std::make_unique<std::complex<float>[]>(length);
-    sampleAdapter->copyRange(mmapData, start, length, dest.get());
+    sampleAdapter->copyRange(mmapData + dataOffset, start, length, dest.get());
 
     return dest;
 }

--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -642,6 +642,16 @@ void InputSource::setSampleRate(double rate)
     invalidate();
 }
 
+void InputSource::setCenterFrequency(double freq)
+{
+    // `frequency` lives on SampleSource<T> and is the value the spectrogram's
+    // frequency axis labels reference (and what derived plots read via
+    // getFrequency()). Auto-init paths (gqrx filenames, etc.) call this so
+    // the axis reads true Hz instead of "0 Hz" baseband.
+    frequency = freq;
+    invalidate();
+}
+
 double InputSource::rate()
 {
     return sampleRate;

--- a/src/inputsource.h
+++ b/src/inputsource.h
@@ -38,11 +38,18 @@ private:
     size_t sampleCount = 0;
     double sampleRate = 0.0;
     uchar *mmapData = nullptr;
+    // Byte offset of the first IQ sample within the mmap. Non-zero for
+    // container formats like Rohde & Schwarz .iq.tar where the raw data
+    // sits after a 512-byte tar header inside the archive.
+    size_t dataOffset = 0;
     std::unique_ptr<SampleAdapter> sampleAdapter;
     std::string _fmt;
     bool _realSignal = false;
 
     QJsonObject readMetaData(const QString &filename);
+    // Populate sampleAdapter / sampleRate / sampleCount / frequency /
+    // dataOffset from a memory-mapped R&S iq.tar archive. Throws on error.
+    void openIqTar(const uchar *data, qint64 size);
 
 public:
     InputSource();

--- a/src/inputsource.h
+++ b/src/inputsource.h
@@ -61,6 +61,7 @@ public:
         return sampleCount;
     };
     void setSampleRate(double rate);
+    void setCenterFrequency(double freq);
     void setFormat(std::string fmt);
     double rate();
     bool realSignal() {

--- a/src/latencylog.h
+++ b/src/latencylog.h
@@ -1,0 +1,58 @@
+/*
+ * Tiny latency-trace helper. Enabled via INSPECTRUM_LAT_LOG=1. Each call
+ * stamps stderr with monotonic microseconds since the first call and the
+ * (truncated) thread id, so a tuner drag produces an easily-readable trace
+ * showing where the time goes between mouse event → worker dispatch →
+ * worker completion → blit. Header-only so adding marks doesn't drag
+ * compile-units; the enabled() check is a single load on the disabled
+ * path, which the optimiser inlines into a no-op everywhere.
+ */
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+class LatencyLog {
+public:
+    static bool enabled() {
+        static const bool e = []() {
+            const char *v = std::getenv("INSPECTRUM_LAT_LOG");
+            return v && v[0] && std::strcmp(v, "0") != 0;
+        }();
+        return e;
+    }
+
+    // Lightweight tag-only mark — preferred for hot paths.
+    static void mark(const char *tag) {
+        if (!enabled()) return;
+        emit_(tag);
+    }
+
+    // printf-style for sites that want to attach values (sample range, etc.).
+    static void markf(const char *fmt, ...) __attribute__((format(printf, 1, 2))) {
+        if (!enabled()) return;
+        char buf[256];
+        va_list ap; va_start(ap, fmt);
+        vsnprintf(buf, sizeof(buf), fmt, ap);
+        va_end(ap);
+        emit_(buf);
+    }
+
+private:
+    static void emit_(const char *msg) {
+        using namespace std::chrono;
+        auto now = steady_clock::now();
+        static const auto t0 = now;
+        auto us = duration_cast<microseconds>(now - t0).count();
+        auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
+        // Single fprintf so concurrent threads don't interleave mid-line.
+        std::fprintf(stderr, "[lat %8lld.%03lldms tid=%04x] %s\n",
+                     (long long)(us / 1000), (long long)(us % 1000),
+                     (unsigned)(tid & 0xffffu), msg);
+    }
+};

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -61,6 +61,9 @@ MainWindow::MainWindow()
     connect(dock, &SpectrogramControls::fastDemodChanged, plots, &PlotView::enableFastDemod);
     // allow user to control number of threads in the Qt thread pool
     connect(dock, &SpectrogramControls::threadsChanged, plots, &PlotView::setMaxThreads);
+    // FM post-demod LPF cutoff and block-average decimation
+    connect(dock, &SpectrogramControls::fmLpfChanged, plots, &PlotView::setFmLpfCutoff);
+    connect(dock, &SpectrogramControls::fmDecimChanged, plots, &PlotView::setFmDecimation);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
 
     // Connect dock outputs

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -61,8 +61,9 @@ MainWindow::MainWindow()
     connect(dock, &SpectrogramControls::fastDemodChanged, plots, &PlotView::enableFastDemod);
     // allow user to control number of threads in the Qt thread pool
     connect(dock, &SpectrogramControls::threadsChanged, plots, &PlotView::setMaxThreads);
-    // FM post-demod LPF cutoff and block-average decimation
+    // FM post-demod LPF cutoff, method, and block-average decimation
     connect(dock, &SpectrogramControls::fmLpfChanged, plots, &PlotView::setFmLpfCutoff);
+    connect(dock, &SpectrogramControls::fmLpfMethodChanged, plots, &PlotView::setFmLpfMethod);
     connect(dock, &SpectrogramControls::fmDecimChanged, plots, &PlotView::setFmDecimation);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -66,6 +66,10 @@ MainWindow::MainWindow()
     connect(dock, &SpectrogramControls::fmLpfMethodChanged, plots, &PlotView::setFmLpfMethod);
     connect(dock, &SpectrogramControls::fmDecimChanged, plots, &PlotView::setFmDecimation);
     connect(dock, &SpectrogramControls::fmPredemodDecimChanged, plots, &PlotView::setFmPredemodDecimation);
+    // Auto-tune button: dock asks PlotView, PlotView picks values and applies
+    // them, then echoes them back so the dock widgets reflect the new state.
+    connect(dock, &SpectrogramControls::autoLpfRequested, plots, &PlotView::autoTuneFmLpf);
+    connect(plots, &PlotView::fmAutoLpfComputed, dock, &SpectrogramControls::applyAutoLpf);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
 
     // Connect dock outputs

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -124,6 +124,22 @@ void MainWindow::openFile(QString fileName)
         }
     }
 
+    // gqrx capture filename: gqrx_<YYYYMMDD>_<HHMMSS>_<centerfreqHz>_<sampleRateHz>_fc.raw
+    // Example: gqrx_20260429_031912_251580000_10000000_fc.raw
+    // Both fields are integer Hz, so a clean regex+toDouble round-trip works.
+    QRegExp gqrxRx("gqrx_\\d{8}_\\d{6}_(\\d+)_(\\d+)_fc\\.raw");
+    if (gqrxRx.exactMatch(basename)) {
+        bool ok = false;
+        double centerHz = gqrxRx.cap(1).toDouble(&ok);
+        if (ok && centerHz > 0.0) {
+            input->setCenterFrequency(centerHz);
+        }
+        double rateHz = gqrxRx.cap(2).toDouble(&ok);
+        if (ok && rateHz > 0.0) {
+            setSampleRate(rateHz);
+        }
+    }
+
     try
     {
         input->openFile(fileName.toUtf8().constData());
@@ -154,9 +170,16 @@ void MainWindow::setSampleRate(QString rate)
     input->setSampleRate(sampleRate);
     plots->setSampleRate(sampleRate);
 
-    // Save the sample rate in settings as we're likely to be opening the same file across multiple runs
-    QSettings settings;
-    settings.setValue("SampleRate", sampleRate);
+    // Save the sample rate in settings as we're likely to be opening the same
+    // file across multiple runs. Skip the save if the value is bogus (≤ 0):
+    // a transient zero (cleared text field, in-flight typing) used to poison
+    // QSettings and turn FrequencyDemod's Hz scaling into "multiply by 0",
+    // which made the FM plot a flat line on the next launch with no obvious
+    // cause.
+    if (sampleRate > 0.0) {
+        QSettings settings;
+        settings.setValue("SampleRate", sampleRate);
+    }
 }
 
 void MainWindow::setSampleRate(double rate)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -143,7 +143,10 @@ void MainWindow::setSampleRate(QString rate)
 
 void MainWindow::setSampleRate(double rate)
 {
-    dock->sampleRate->setText(QString::number(rate));
+    // 'g' format (the QString::number default) switches to scientific at 7+
+    // digits, so 10 MHz renders as "1e+07" and looks to the user like the
+    // rate didn't parse. Display sample rates as plain integers in Hz.
+    dock->sampleRate->setText(QString::number(rate, 'f', 0));
 }
 
 void MainWindow::setFormat(QString fmt)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -65,6 +65,7 @@ MainWindow::MainWindow()
     connect(dock, &SpectrogramControls::fmLpfChanged, plots, &PlotView::setFmLpfCutoff);
     connect(dock, &SpectrogramControls::fmLpfMethodChanged, plots, &PlotView::setFmLpfMethod);
     connect(dock, &SpectrogramControls::fmDecimChanged, plots, &PlotView::setFmDecimation);
+    connect(dock, &SpectrogramControls::fmPredemodDecimChanged, plots, &PlotView::setFmPredemodDecimation);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
 
     // Connect dock outputs

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -72,6 +72,7 @@ MainWindow::MainWindow()
     connect(plots, &PlotView::fmAutoLpfComputed, dock, &SpectrogramControls::applyAutoLpf);
     // Auto period-detection on the visible FM trace, fed into the dock label.
     connect(plots, &PlotView::autoPeriodChanged, dock, &SpectrogramControls::applyAutoPeriod);
+    connect(dock, &SpectrogramControls::periodAnalysisChanged, plots, &PlotView::setPeriodAnalysisEnabled);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
 
     // Connect dock outputs

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -81,8 +81,10 @@ MainWindow::MainWindow()
 
     // Set defaults after making connections so everything is in sync
     dock->setDefaults();
-    // Show cursor (mouse) position in time and frequency in the status bar.
-    // valueText is filled when the cursor is over a derived trace plot.
+    // Show cursor (mouse) position in time and frequency in the status bar
+    // *and* mirror the sample value under the cursor into the dock's
+    // "Cursor value:" label (the dock entry is the discoverable one; the
+    // status bar text is just a bonus for users used to looking down).
     connect(plots, &PlotView::mousePositionChanged,
             this, [this](double timePos, double freqPos, QString valueText) {
         QString msg = QString("Time: %1 s   Freq: %2 Hz")
@@ -92,6 +94,7 @@ MainWindow::MainWindow()
             msg += QStringLiteral("   Value: ") + valueText;
         }
         statusBar()->showMessage(msg, 0);
+        this->dock->applyCursorValue(valueText);
     });
 
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -70,6 +70,8 @@ MainWindow::MainWindow()
     // them, then echoes them back so the dock widgets reflect the new state.
     connect(dock, &SpectrogramControls::autoLpfRequested, plots, &PlotView::autoTuneFmLpf);
     connect(plots, &PlotView::fmAutoLpfComputed, dock, &SpectrogramControls::applyAutoLpf);
+    // Auto period-detection on the visible FM trace, fed into the dock label.
+    connect(plots, &PlotView::autoPeriodChanged, dock, &SpectrogramControls::applyAutoPeriod);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
 
     // Connect dock outputs

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -79,13 +79,16 @@ MainWindow::MainWindow()
 
     // Set defaults after making connections so everything is in sync
     dock->setDefaults();
-    // Show cursor (mouse) position in time and frequency in the status bar
+    // Show cursor (mouse) position in time and frequency in the status bar.
+    // valueText is filled when the cursor is over a derived trace plot.
     connect(plots, &PlotView::mousePositionChanged,
-            this, [this](double timePos, double freqPos) {
-        // Format with 6 decimal places for time, frequency in Hz
+            this, [this](double timePos, double freqPos, QString valueText) {
         QString msg = QString("Time: %1 s   Freq: %2 Hz")
             .arg(timePos, 0, 'f', 6)
             .arg(freqPos, 0, 'f', 0);
+        if (!valueText.isEmpty()) {
+            msg += QStringLiteral("   Value: ") + valueText;
+        }
         statusBar()->showMessage(msg, 0);
     });
 

--- a/src/plot.h
+++ b/src/plot.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <QMouseEvent>
+#include <QWheelEvent>
 #include <QObject>
 #include <QPainter>
 #include "abstractsamplesource.h"
@@ -34,6 +35,8 @@ public:
     ~Plot();
     void invalidateEvent() override;
     virtual bool mouseEvent(QEvent::Type type, QMouseEvent event);
+    /** Handle wheel events (vertical zoom) */
+    virtual bool wheelEvent(QWheelEvent *event) { Q_UNUSED(event); return false; }
     virtual std::shared_ptr<AbstractSampleSource> output();
     virtual void paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     virtual void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -19,6 +19,7 @@
 
 #include "plotview.h"
 #include "frequencydemod.h"
+#include "util.h"
 #include <QPixmapCache>
 #include <iostream>
 #include <fstream>
@@ -201,20 +202,20 @@ void PlotView::analyzeVisiblePeriod()
 {
     // Find the first derived float-source plot (FM trace by convention) and
     // estimate its dominant period over the currently-visible sample range
-    // by counting zero crossings around the trace's mean. Cheap, robust to
-    // amplitude scale, and works for any roughly-periodic signal — won't
-    // give meaningful numbers for noise or a flat trace, which the
-    // applyAutoPeriod() consumer handles by displaying "—".
+    // by counting upward crossings of the trace's mean (with hysteresis).
+    // Records each detected crossing point so TracePlot::paintFront can
+    // overlay markers + a connecting line.
     if (sampleRate <= 0.0) {
         emit autoPeriodChanged(0.0);
         return;
     }
+    TracePlot *targetPlot = nullptr;
     SampleSource<float> *fsrc = nullptr;
     for (auto &plt : plots) {
         auto tp = dynamic_cast<TracePlot*>(plt.get());
         if (!tp) continue;
         auto typed = std::dynamic_pointer_cast<SampleSource<float>>(tp->source());
-        if (typed) { fsrc = typed.get(); break; }
+        if (typed) { fsrc = typed.get(); targetPlot = tp; break; }
     }
     if (!fsrc) {
         emit autoPeriodChanged(0.0);
@@ -227,6 +228,7 @@ void PlotView::analyzeVisiblePeriod()
     size_t n = viewRange.maximum > viewRange.minimum
              ? (viewRange.maximum - viewRange.minimum) : 0;
     if (n < 256) {
+        if (targetPlot) targetPlot->setPeriodMarkers({});
         emit autoPeriodChanged(0.0);
         return;
     }
@@ -234,6 +236,7 @@ void PlotView::analyzeVisiblePeriod()
 
     auto data = fsrc->getSamples(viewRange.minimum, n);
     if (!data) {
+        if (targetPlot) targetPlot->setPeriodMarkers({});
         emit autoPeriodChanged(0.0);
         return;
     }
@@ -244,13 +247,12 @@ void PlotView::analyzeVisiblePeriod()
         if (std::isfinite(data[i])) { sum += data[i]; ++valid; }
     }
     if (valid < 256) {
+        if (targetPlot) targetPlot->setPeriodMarkers({});
         emit autoPeriodChanged(0.0);
         return;
     }
     const double mean = sum / valid;
 
-    // Hysteresis around the mean to avoid counting noise-level wobbles as
-    // crossings. Use a small fraction of the trace's span as a deadband.
     double mn = std::numeric_limits<double>::infinity();
     double mx = -std::numeric_limits<double>::infinity();
     for (size_t i = 0; i < n; ++i) {
@@ -260,32 +262,38 @@ void PlotView::analyzeVisiblePeriod()
     }
     const double span = mx - mn;
     if (span <= 0.0) {
+        if (targetPlot) targetPlot->setPeriodMarkers({});
         emit autoPeriodChanged(0.0);
         return;
     }
     const double hyst = 0.1 * span;
 
-    // Count low-to-high crossings of the (data - mean) signal, with the
-    // value first having to dip below mean - hyst before a crossing back
-    // above mean + hyst counts. Each such crossing = one full period.
-    int periods = 0;
+    // Each upward crossing of (data - mean) = 0 with hysteresis = one
+    // period boundary. Record the absolute sample index of each crossing
+    // so the plot can render markers.
+    std::vector<size_t> peaks;
     bool armedLow = false;
     for (size_t i = 0; i < n; ++i) {
         if (!std::isfinite(data[i])) continue;
         const double d = data[i] - mean;
         if (d < -hyst) armedLow = true;
         else if (armedLow && d > hyst) {
-            ++periods;
+            peaks.push_back(viewRange.minimum + i);
             armedLow = false;
         }
     }
-    if (periods < 2) {
+    if (peaks.size() < 2) {
+        if (targetPlot) targetPlot->setPeriodMarkers({});
         emit autoPeriodChanged(0.0);
         return;
     }
-    const double duration = static_cast<double>(n) / sampleRate;
-    const double period = duration / periods;
-    emit autoPeriodChanged(period);
+    // Period = (last peak time - first peak time) / (peaks - 1) — uses the
+    // span between detected peaks rather than the visible duration so an
+    // off-by-one near the edges doesn't bias the estimate.
+    const double dt = static_cast<double>(peaks.back() - peaks.front())
+                    / (peaks.size() - 1) / sampleRate;
+    if (targetPlot) targetPlot->setPeriodMarkers(std::move(peaks));
+    emit autoPeriodChanged(dt);
 }
 
 void PlotView::addPlot(Plot *plot)
@@ -324,15 +332,20 @@ void PlotView::mouseMoveEvent(QMouseEvent *event)
     // Derived plots are stacked at the bottom of the viewport (each
     // `derivedPlotHeight` tall). Top of the stack is at viewportH minus
     // their total height. If the cursor is below that, it's over a derived
-    // plot — figure out which one and read its value at this x.
+    // plot — figure out which one, read its value, and push a hover-cursor
+    // overlay to that plot. Clear hover on every other derived plot so
+    // only the active one shows the marker.
     const int derivedCount = static_cast<int>(plots.size()) - 1;
     const int derivedTotalH = derivedCount * derivedPlotHeight;
     const int derivedTop = viewportH - derivedTotalH;
+    int activePlotIdx = -1;
+    double hoverValue = std::numeric_limits<double>::quiet_NaN();
     if (derivedCount > 0 && y >= derivedTop) {
         const int posInDerived = y - derivedTop;
         const int plotIdx = 1 + posInDerived / derivedPlotHeight;
         if (plotIdx >= 1 && static_cast<size_t>(plotIdx) < plots.size()) {
-            valueText = sampleValueText(plots[plotIdx].get(), sampleIdx);
+            activePlotIdx = plotIdx;
+            valueText = sampleValueText(plots[plotIdx].get(), sampleIdx, &hoverValue);
         }
     } else {
         // Cursor is over the spectrogram (scrollable) — compute frequency
@@ -346,32 +359,57 @@ void PlotView::mouseMoveEvent(QMouseEvent *event)
         }
     }
 
+    // Push hover state onto the active derived plot, clear all others.
+    for (size_t i = 1; i < plots.size(); ++i) {
+        if (auto tp = dynamic_cast<TracePlot*>(plots[i].get())) {
+            if (static_cast<int>(i) == activePlotIdx) {
+                tp->setHoverCursor(true, sampleIdx, hoverValue, valueText);
+            } else {
+                tp->setHoverCursor(false, 0, 0.0, QString());
+            }
+        }
+    }
+
     emit mousePositionChanged(timePos, freqPos, valueText);
     QGraphicsView::mouseMoveEvent(event);
 }
 
-QString PlotView::sampleValueText(Plot *plot, size_t sampleIdx)
+QString PlotView::sampleValueText(Plot *plot, size_t sampleIdx, double *rawValueOut)
 {
+    if (rawValueOut) *rawValueOut = std::numeric_limits<double>::quiet_NaN();
     auto tp = dynamic_cast<TracePlot*>(plot);
     if (!tp) return QString();
     auto src = tp->source();
     if (!src) return QString();
 
-    // Float source (FM, AM, threshold): read one sample and format.
+    // Float source. Distinguish FM (FrequencyDemod) so we can convert the
+    // freqdem's normalised output to instantaneous frequency in Hz —
+    // f_inst = m · kf · Fs, with kf = 0.49 fixed in FrequencyDemod's ctor.
     if (auto fsrc = std::dynamic_pointer_cast<SampleSource<float>>(src)) {
         auto data = fsrc->getSamples(sampleIdx, 1);
         if (!data) return QString();
         float v = data[0];
+        if (rawValueOut) *rawValueOut = v;
         if (!std::isfinite(v)) return QStringLiteral("NaN");
+        if (dynamic_cast<FrequencyDemod*>(src.get()) && sampleRate > 0.0) {
+            const double kf = 0.49;
+            const double instHz = static_cast<double>(v) * kf * sampleRate;
+            return QStringLiteral("%1 Hz")
+                .arg(QString::fromStdString(formatSIValue(instHz)));
+        }
+        // AM and threshold are dimensionless w.r.t. the IQ scale —
+        // just show the raw float so the user sees the same number
+        // they'd read off the y-axis label.
         return QString::number(v, 'g', 6);
     }
-    // Complex source (IQ plot): show I and Q separately plus magnitude.
+    // Complex source (IQ plot): show I and Q plus magnitude.
     if (auto csrc = std::dynamic_pointer_cast<SampleSource<std::complex<float>>>(src)) {
         auto data = csrc->getSamples(sampleIdx, 1);
         if (!data) return QString();
         float i = data[0].real();
         float q = data[0].imag();
         float mag = std::hypot(i, q);
+        if (rawValueOut) *rawValueOut = mag;
         return QStringLiteral("I=%1 Q=%2 |·|=%3")
             .arg(i, 0, 'g', 4)
             .arg(q, 0, 'g', 4)

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -398,24 +398,22 @@ QString PlotView::sampleValueText(Plot *plot, size_t sampleIdx, double *rawValue
     auto src = tp->source();
     if (!src) return QString();
 
-    // Float source. Distinguish FM (FrequencyDemod) so we can convert the
-    // freqdem's normalised output to instantaneous frequency in Hz —
-    // f_inst = m · kf · Fs, with kf = 0.49 fixed in FrequencyDemod's ctor.
+    // Float source. FrequencyDemod now scales its output to Hz at the
+    // source (see fillBatchCache / work in frequencydemod.cpp), so all the
+    // hover formatter has to do is detect "this is the FM trace" and
+    // append "Hz". The Y-axis labels read in Hz too — same value either
+    // way. AM and threshold are dimensionless w.r.t. the IQ scale, so
+    // show the raw float.
     if (auto fsrc = std::dynamic_pointer_cast<SampleSource<float>>(src)) {
         auto data = fsrc->getSamples(sampleIdx, 1);
         if (!data) return QString();
         float v = data[0];
         if (rawValueOut) *rawValueOut = v;
         if (!std::isfinite(v)) return QStringLiteral("NaN");
-        if (dynamic_cast<FrequencyDemod*>(src.get()) && sampleRate > 0.0) {
-            const double kf = 0.49;
-            const double instHz = static_cast<double>(v) * kf * sampleRate;
-            return QStringLiteral("%1 Hz")
-                .arg(QString::fromStdString(formatSIValue(instHz)));
+        if (dynamic_cast<FrequencyDemod*>(src.get())) {
+            return QStringLiteral("%1Hz")
+                .arg(QString::fromStdString(formatSIValue(v)));
         }
-        // AM and threshold are dimensionless w.r.t. the IQ scale —
-        // just show the raw float so the user sees the same number
-        // they'd read off the y-axis label.
         return QString::number(v, 'g', 6);
     }
     // Complex source (IQ plot): show I and Q plus magnitude.

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -26,6 +26,7 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QDebug>
+#include <QWheelEvent>
 #include <QFileDialog>
 #include <QGridLayout>
 #include <QGroupBox>
@@ -288,16 +289,14 @@ void PlotView::enableCursors(bool enabled)
 bool PlotView::viewportEvent(QEvent *event) {
     // Handle wheel events for zooming (before the parent's handler to stop normal scrolling)
     if (event->type() == QEvent::Wheel) {
-        QWheelEvent *wheelEvent = (QWheelEvent*)event;
+        QWheelEvent *wheelEvent = static_cast<QWheelEvent*>(event);
+        // Ctrl+wheel: horizontal zoom
         if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
             bool canZoomIn = zoomLevel < fftSize;
             bool canZoomOut = zoomLevel > -64;
             int delta = wheelEvent->angleDelta().y();
             if ((delta > 0 && canZoomIn) || (delta < 0 && canZoomOut)) {
                 scrollZoomStepsAccumulated += delta;
-
-                // `updateViewRange()` keeps the center sample in the same place after zoom. Apply
-                // a scroll adjustment to keep the sample under the mouse cursor in the same place instead.
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
                 zoomPos = wheelEvent->position().x();
 #else
@@ -313,6 +312,24 @@ bool PlotView::viewportEvent(QEvent *event) {
                 }
             }
             return true;
+        }
+        // No modifier: forward to plots for vertical zoom
+        {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+            int viewY = int(wheelEvent->position().y());
+#else
+            int viewY = wheelEvent->pos().y();
+#endif
+            int plotY = -verticalScrollBar()->value();
+            for (auto&& plot : plots) {
+                int ph = plot->height();
+                if (viewY >= plotY && viewY < plotY + ph) {
+                    if (plot->wheelEvent(wheelEvent))
+                        return true;
+                    break;
+                }
+                plotY += ph;
+            }
         }
     }
 

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -198,6 +198,22 @@ void PlotView::autoTuneFmLpf()
     emit fmAutoLpfComputed(cutoff, M, N);
 }
 
+void PlotView::setPeriodAnalysisEnabled(bool enabled)
+{
+    periodAnalysisEnabled = enabled;
+    if (enabled) {
+        if (periodTimer) periodTimer->start();
+    } else {
+        // Clear any existing markers and the dock label.
+        for (auto &plt : plots) {
+            if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
+                tp->setPeriodMarkers({});
+            }
+        }
+        emit autoPeriodChanged(0.0);
+    }
+}
+
 void PlotView::analyzeVisiblePeriod()
 {
     // Find the first derived float-source plot (FM trace by convention) and
@@ -205,7 +221,7 @@ void PlotView::analyzeVisiblePeriod()
     // by counting upward crossings of the trace's mean (with hysteresis).
     // Records each detected crossing point so TracePlot::paintFront can
     // overlay markers + a connecting line.
-    if (sampleRate <= 0.0) {
+    if (!periodAnalysisEnabled || sampleRate <= 0.0) {
         emit autoPeriodChanged(0.0);
         return;
     }

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -205,25 +205,74 @@ void PlotView::addPlot(Plot *plot)
 void PlotView::mouseMoveEvent(QMouseEvent *event)
 {
     updateAnnotationTooltip(event);
-    // Emit current mouse position in time and frequency for status display
-    {
-        // Map X position to time (seconds)
-        int x = event->pos().x();
-        int hScroll = horizontalScrollBar()->value();
-        size_t sampleIdx = columnToSample(x + hScroll);
-        double timePos = (sampleRate > 0.0) ? (sampleIdx / sampleRate) : 0.0;
-        // Map Y position to frequency offset (Hz), with DC at center of spectrogram
-        double freqPos = 0.0;
+
+    int x = event->pos().x();
+    int y = event->pos().y();
+    int hScroll = horizontalScrollBar()->value();
+    size_t sampleIdx = columnToSample(x + hScroll);
+    double timePos = (sampleRate > 0.0) ? (sampleIdx / sampleRate) : 0.0;
+    int viewportH = viewport()->height();
+
+    double freqPos = 0.0;
+    QString valueText;
+
+    // Derived plots are stacked at the bottom of the viewport (each
+    // `derivedPlotHeight` tall). Top of the stack is at viewportH minus
+    // their total height. If the cursor is below that, it's over a derived
+    // plot — figure out which one and read its value at this x.
+    const int derivedCount = static_cast<int>(plots.size()) - 1;
+    const int derivedTotalH = derivedCount * derivedPlotHeight;
+    const int derivedTop = viewportH - derivedTotalH;
+    if (derivedCount > 0 && y >= derivedTop) {
+        const int posInDerived = y - derivedTop;
+        const int plotIdx = 1 + posInDerived / derivedPlotHeight;
+        if (plotIdx >= 1 && static_cast<size_t>(plotIdx) < plots.size()) {
+            valueText = sampleValueText(plots[plotIdx].get(), sampleIdx);
+        }
+    } else {
+        // Cursor is over the spectrogram (scrollable) — compute frequency
+        // offset from Y so the existing status-bar field stays correct.
         int vScroll = verticalScrollBar()->value();
-        int contentY = event->pos().y() + vScroll;
+        int contentY = y + vScroll;
         int plotH = spectrogramPlot->height();
         if (contentY >= 0 && contentY < plotH && sampleRate > 0.0) {
             double hzPerPixel = sampleRate / plotH;
             freqPos = ((plotH / 2.0) - contentY) * hzPerPixel;
         }
-        emit mousePositionChanged(timePos, freqPos);
     }
+
+    emit mousePositionChanged(timePos, freqPos, valueText);
     QGraphicsView::mouseMoveEvent(event);
+}
+
+QString PlotView::sampleValueText(Plot *plot, size_t sampleIdx)
+{
+    auto tp = dynamic_cast<TracePlot*>(plot);
+    if (!tp) return QString();
+    auto src = tp->source();
+    if (!src) return QString();
+
+    // Float source (FM, AM, threshold): read one sample and format.
+    if (auto fsrc = std::dynamic_pointer_cast<SampleSource<float>>(src)) {
+        auto data = fsrc->getSamples(sampleIdx, 1);
+        if (!data) return QString();
+        float v = data[0];
+        if (!std::isfinite(v)) return QStringLiteral("NaN");
+        return QString::number(v, 'g', 6);
+    }
+    // Complex source (IQ plot): show I and Q separately plus magnitude.
+    if (auto csrc = std::dynamic_pointer_cast<SampleSource<std::complex<float>>>(src)) {
+        auto data = csrc->getSamples(sampleIdx, 1);
+        if (!data) return QString();
+        float i = data[0].real();
+        float q = data[0].imag();
+        float mag = std::hypot(i, q);
+        return QStringLiteral("I=%1 Q=%2 |·|=%3")
+            .arg(i, 0, 'g', 4)
+            .arg(q, 0, 'g', 4)
+            .arg(mag, 0, 'g', 4);
+    }
+    return QString();
 }
 
 void PlotView::mouseReleaseEvent(QMouseEvent *event)

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -40,6 +40,7 @@
 #include <QToolTip>
 #include <QVBoxLayout>
 #include "plots.h"
+#include "latencylog.h"
 #include <QThreadPool>
 
 PlotView::PlotView(InputSource *input) : cursors(this), viewRange({0, 0}), derivedPlotHeight(200)
@@ -631,6 +632,11 @@ void PlotView::enableCursors(bool enabled)
 }
 
 bool PlotView::viewportEvent(QEvent *event) {
+    if (event->type() == QEvent::MouseMove) {
+        LatencyLog::mark("MouseMove ----------");
+    } else if (event->type() == QEvent::Wheel) {
+        LatencyLog::mark("Wheel ----------");
+    }
     // Handle wheel events for zooming (before the parent's handler to stop normal scrolling)
     if (event->type() == QEvent::Wheel) {
         QWheelEvent *wheelEvent = static_cast<QWheelEvent*>(event);
@@ -912,6 +918,7 @@ void PlotView::setPowerMax(int power)
 void PlotView::paintEvent(QPaintEvent *event)
 {
     if (mainSampleSource == nullptr) return;
+    LatencyLog::mark("paintEvent start");
 
     // Full viewport rectangle
     QRect viewRect(0, 0, width(), height());
@@ -942,13 +949,21 @@ void PlotView::paintEvent(QPaintEvent *event)
         paintTimeScale(painter, specRect, viewRange);
     }
 
-    // Draw derived plots in a fixed area at the bottom (always visible)
+    // Draw derived plots in a fixed area at the bottom (always visible).
+    // When the file ends before the viewport's right edge (zoomed-out short
+    // capture, or panned past EOF), viewRange is clamped to the file length
+    // by updateViewRange — so the actual content width is the pixel span of
+    // viewRange at the current zoom, not the full viewport. Stretching N
+    // samples across the full width here makes the derived plots disagree
+    // with the spectrogram column-for-column.
+    int contentWidth = std::min<int>(width(), sampleToColumn(viewRange.length()));
+    if (contentWidth < 1) contentWidth = 1;
     if (derivedHeight > 0) {
         // Back layer
         int y = viewRect.height() - derivedHeight;
         for (size_t i = 1; i < plots.size(); ++i) {
             Plot *plot = plots[i].get();
-            QRect rect(0, y, width(), plot->height());
+            QRect rect(0, y, contentWidth, plot->height());
             plot->paintBack(painter, rect, viewRange);
             y += plot->height();
         }
@@ -956,7 +971,7 @@ void PlotView::paintEvent(QPaintEvent *event)
         y = viewRect.height() - derivedHeight;
         for (size_t i = 1; i < plots.size(); ++i) {
             Plot *plot = plots[i].get();
-            QRect rect(0, y, width(), plot->height());
+            QRect rect(0, y, contentWidth, plot->height());
             plot->paintMid(painter, rect, viewRange);
             y += plot->height();
         }
@@ -964,11 +979,12 @@ void PlotView::paintEvent(QPaintEvent *event)
         y = viewRect.height() - derivedHeight;
         for (size_t i = 1; i < plots.size(); ++i) {
             Plot *plot = plots[i].get();
-            QRect rect(0, y, width(), plot->height());
+            QRect rect(0, y, contentWidth, plot->height());
             plot->paintFront(painter, rect, viewRange);
             y += plot->height();
         }
     }
+    LatencyLog::mark("paintEvent end");
 }
 
 void PlotView::paintTimeScale(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
@@ -1045,6 +1061,7 @@ size_t PlotView::samplesPerColumn()
 
 void PlotView::scrollContentsBy(int dx, int dy)
 {
+    LatencyLog::markf("scrollContentsBy dx=%d dy=%d", dx, dy);
     updateView();
 }
 

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -214,6 +214,9 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
 
     Plot *selectedPlot = nullptr;
     size_t plotIndex = 0;
+    // Tuner Y for any new derived plot: -1 means "leave tuner alone" (e.g.
+    // the click was in an existing derived plot, not the spectrogram).
+    int tunerCentreY = -1;
     // Check if click is in derived plot area (fixed at bottom)
     if (plots.size() > 1 && clickY >= viewportH - derivedPlotHeight) {
         int posInDerived = clickY - (viewportH - derivedPlotHeight);
@@ -228,6 +231,7 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
             return;
         plotIndex = 0;
         selectedPlot = plots[0].get();
+        tunerCentreY = contentY;
     }
 
     // Compute center position for recentering
@@ -245,6 +249,10 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
         connect(
             trioAction, &QAction::triggered,
             this, [=]() {
+                // Tune the spectrogram tuner to the click position so the
+                // new derived plots see the signal under the cursor.
+                if (tunerCentreY >= 0)
+                    spectrogramPlot->setTunerCentreY(tunerCentreY);
                 // Order: sample (IQ) first, amplitude (AM) second, frequency (FM) last
                 addPlot(Plots::samplePlot(src));
                 addPlot(Plots::amplitudePlot(src));
@@ -264,6 +272,11 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
         connect(
             action, &QAction::triggered,
             this, [=]() {
+                // Tune the spectrogram tuner to the click Y first; the new
+                // plot subscribes to tunerTransform so it picks up the new
+                // centre frequency on its first paint.
+                if (tunerCentreY >= 0)
+                    spectrogramPlot->setTunerCentreY(tunerCentreY);
                 // Add the new derived plot
                 addPlot(plotCreator(src));
                 // Re-center view so clickSample is at center

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -63,6 +63,16 @@ PlotView::PlotView(InputSource *input) : cursors(this), viewRange({0, 0}), deriv
     addPlot(spectrogramPlot);
 
     mainSampleSource->subscribe(this);
+
+    // Debounced re-analysis of the visible FM trace's dominant period.
+    // Restarted from updateView() and from every FM-filter setter so the
+    // dock label stays in sync with what the user sees, but only one scan
+    // runs per idle period.
+    periodTimer = new QTimer(this);
+    periodTimer->setSingleShot(true);
+    periodTimer->setInterval(200);
+    connect(periodTimer, &QTimer::timeout,
+            this, &PlotView::analyzeVisiblePeriod);
 }
 
 void PlotView::enableFastDemod(bool enabled)
@@ -100,6 +110,7 @@ void PlotView::setFmLpfCutoff(double hz)
     }
     QPixmapCache::clear();
     viewport()->update();
+    if (periodTimer) periodTimer->start();
 }
 
 void PlotView::setFmDecimation(int n)
@@ -115,6 +126,7 @@ void PlotView::setFmDecimation(int n)
     }
     QPixmapCache::clear();
     viewport()->update();
+    if (periodTimer) periodTimer->start();
 }
 
 void PlotView::setFmLpfMethod(int method)
@@ -130,6 +142,7 @@ void PlotView::setFmLpfMethod(int method)
     }
     QPixmapCache::clear();
     viewport()->update();
+    if (periodTimer) periodTimer->start();
 }
 
 void PlotView::setFmPredemodDecimation(int m)
@@ -145,6 +158,7 @@ void PlotView::setFmPredemodDecimation(int m)
     }
     QPixmapCache::clear();
     viewport()->update();
+    if (periodTimer) periodTimer->start();
 }
 
 void PlotView::autoTuneFmLpf()
@@ -181,6 +195,97 @@ void PlotView::autoTuneFmLpf()
     setFmPredemodDecimation(M);
     setFmDecimation(N);
     emit fmAutoLpfComputed(cutoff, M, N);
+}
+
+void PlotView::analyzeVisiblePeriod()
+{
+    // Find the first derived float-source plot (FM trace by convention) and
+    // estimate its dominant period over the currently-visible sample range
+    // by counting zero crossings around the trace's mean. Cheap, robust to
+    // amplitude scale, and works for any roughly-periodic signal — won't
+    // give meaningful numbers for noise or a flat trace, which the
+    // applyAutoPeriod() consumer handles by displaying "—".
+    if (sampleRate <= 0.0) {
+        emit autoPeriodChanged(0.0);
+        return;
+    }
+    SampleSource<float> *fsrc = nullptr;
+    for (auto &plt : plots) {
+        auto tp = dynamic_cast<TracePlot*>(plt.get());
+        if (!tp) continue;
+        auto typed = std::dynamic_pointer_cast<SampleSource<float>>(tp->source());
+        if (typed) { fsrc = typed.get(); break; }
+    }
+    if (!fsrc) {
+        emit autoPeriodChanged(0.0);
+        return;
+    }
+
+    // Limit the analysis size — the FFT-free zero-crossing pass is O(N) and
+    // we just need a reasonable estimate, not microsecond precision.
+    constexpr size_t kMaxAnalyseSamples = 200000;
+    size_t n = viewRange.maximum > viewRange.minimum
+             ? (viewRange.maximum - viewRange.minimum) : 0;
+    if (n < 256) {
+        emit autoPeriodChanged(0.0);
+        return;
+    }
+    if (n > kMaxAnalyseSamples) n = kMaxAnalyseSamples;
+
+    auto data = fsrc->getSamples(viewRange.minimum, n);
+    if (!data) {
+        emit autoPeriodChanged(0.0);
+        return;
+    }
+
+    double sum = 0.0;
+    size_t valid = 0;
+    for (size_t i = 0; i < n; ++i) {
+        if (std::isfinite(data[i])) { sum += data[i]; ++valid; }
+    }
+    if (valid < 256) {
+        emit autoPeriodChanged(0.0);
+        return;
+    }
+    const double mean = sum / valid;
+
+    // Hysteresis around the mean to avoid counting noise-level wobbles as
+    // crossings. Use a small fraction of the trace's span as a deadband.
+    double mn = std::numeric_limits<double>::infinity();
+    double mx = -std::numeric_limits<double>::infinity();
+    for (size_t i = 0; i < n; ++i) {
+        if (!std::isfinite(data[i])) continue;
+        if (data[i] < mn) mn = data[i];
+        if (data[i] > mx) mx = data[i];
+    }
+    const double span = mx - mn;
+    if (span <= 0.0) {
+        emit autoPeriodChanged(0.0);
+        return;
+    }
+    const double hyst = 0.1 * span;
+
+    // Count low-to-high crossings of the (data - mean) signal, with the
+    // value first having to dip below mean - hyst before a crossing back
+    // above mean + hyst counts. Each such crossing = one full period.
+    int periods = 0;
+    bool armedLow = false;
+    for (size_t i = 0; i < n; ++i) {
+        if (!std::isfinite(data[i])) continue;
+        const double d = data[i] - mean;
+        if (d < -hyst) armedLow = true;
+        else if (armedLow && d > hyst) {
+            ++periods;
+            armedLow = false;
+        }
+    }
+    if (periods < 2) {
+        emit autoPeriodChanged(0.0);
+        return;
+    }
+    const double duration = static_cast<double>(n) / sampleRate;
+    const double period = duration / periods;
+    emit autoPeriodChanged(period);
 }
 
 void PlotView::addPlot(Plot *plot)
@@ -948,6 +1053,8 @@ void PlotView::updateView(bool reCenter, bool expanding)
 
     // Re-paint
     viewport()->update();
+    // Re-analyse the visible FM trace's period after the view settles.
+    if (periodTimer) periodTimer->start();
 }
 
 void PlotView::setSampleRate(double rate)

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -147,6 +147,42 @@ void PlotView::setFmPredemodDecimation(int m)
     viewport()->update();
 }
 
+void PlotView::autoTuneFmLpf()
+{
+    if (!spectrogramPlot || sampleRate <= 0.0) return;
+    auto src = spectrogramPlot->output();
+    if (!src) return;
+    // relativeBandwidth is the tuner span as a fraction of Fs. It lives on
+    // SampleSource<T>, not AbstractSampleSource, so we have to cast — the
+    // tuner output is always complex<float>.
+    auto typed = std::dynamic_pointer_cast<SampleSource<std::complex<float>>>(src);
+    double relBw = typed ? typed->relativeBandwidth() : 1.0;
+    if (relBw <= 0.0 || relBw > 1.0) relBw = 1.0;
+    const double tunerBw = relBw * sampleRate;
+
+    // Heuristic cutoff: tunerBw / 50 — captures the slowly-varying envelope
+    // of typical FM modulation while clamping to a usable range so very
+    // wide or very narrow tuners still get a sane number.
+    double cutoff = tunerBw / 50.0;
+    if (cutoff < 500.0)   cutoff = 500.0;
+    if (cutoff > 50000.0) cutoff = 50000.0;
+
+    // Pre-demod decimation must keep the freqdem's effective Nyquist above
+    // tunerBw — i.e. M ≤ 1/(2·relBw). Pick 80% of that for safety. Also
+    // bound by a useful-cutoff target (Fs/(4·fc)) so we don't decimate
+    // past what the post-LPF can take advantage of, and a hard ceiling to
+    // keep msresamp's per-stage halfband cost bounded.
+    int M_alias = std::max(1, static_cast<int>(std::floor(0.8 / (2.0 * relBw))));
+    int M_lpf   = std::max(1, static_cast<int>(std::floor(sampleRate / (4.0 * cutoff))));
+    int M = std::min({M_alias, M_lpf, 100});
+    int N = 1; // post-decim adds nothing once predemod decim is on
+
+    setFmLpfCutoff(cutoff);
+    setFmPredemodDecimation(M);
+    setFmDecimation(N);
+    emit fmAutoLpfComputed(cutoff, M, N);
+}
+
 void PlotView::addPlot(Plot *plot)
 {
     plots.emplace_back(plot);

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -117,6 +117,21 @@ void PlotView::setFmDecimation(int n)
     viewport()->update();
 }
 
+void PlotView::setFmLpfMethod(int method)
+{
+    fmLpfMethod = method;
+    auto m = static_cast<FrequencyDemod::LpfMethod>(method);
+    for (auto &plt : plots) {
+        if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
+            if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
+                fd->setPostLpfMethod(m);
+            }
+        }
+    }
+    QPixmapCache::clear();
+    viewport()->update();
+}
+
 void PlotView::addPlot(Plot *plot)
 {
     plots.emplace_back(plot);
@@ -127,6 +142,7 @@ void PlotView::addPlot(Plot *plot)
     // Propagate the currently-configured FM settings to any newly added FM plot.
     if (auto tp = dynamic_cast<TracePlot*>(plot)) {
         if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
+            fd->setPostLpfMethod(static_cast<FrequencyDemod::LpfMethod>(fmLpfMethod));
             fd->setPostLpfCutoff(fmLpfCutoffHz);
             fd->setPostDecimation(fmDecim);
         }

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -87,12 +87,49 @@ void PlotView::setMaxThreads(int threads)
     // configure the global QThreadPool for QtConcurrent::run
     QThreadPool::globalInstance()->setMaxThreadCount(threads);
 }
+
+void PlotView::setFmLpfCutoff(double hz)
+{
+    fmLpfCutoffHz = hz;
+    for (auto &plt : plots) {
+        if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
+            if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
+                fd->setPostLpfCutoff(hz);
+            }
+        }
+    }
+    QPixmapCache::clear();
+    viewport()->update();
+}
+
+void PlotView::setFmDecimation(int n)
+{
+    if (n < 1) n = 1;
+    fmDecim = n;
+    for (auto &plt : plots) {
+        if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
+            if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
+                fd->setPostDecimation(n);
+            }
+        }
+    }
+    QPixmapCache::clear();
+    viewport()->update();
+}
+
 void PlotView::addPlot(Plot *plot)
 {
     plots.emplace_back(plot);
     // If this is a derived plot (not the main spectrogram), set its height
     if (plots.size() > 1) {
         plot->setPlotHeight(derivedPlotHeight);
+    }
+    // Propagate the currently-configured FM settings to any newly added FM plot.
+    if (auto tp = dynamic_cast<TracePlot*>(plot)) {
+        if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
+            fd->setPostLpfCutoff(fmLpfCutoffHz);
+            fd->setPostDecimation(fmDecim);
+        }
     }
     connect(plot, &Plot::repaint, this, &PlotView::repaint);
 }

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -132,6 +132,21 @@ void PlotView::setFmLpfMethod(int method)
     viewport()->update();
 }
 
+void PlotView::setFmPredemodDecimation(int m)
+{
+    if (m < 1) m = 1;
+    fmPredemodDecim = m;
+    for (auto &plt : plots) {
+        if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
+            if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
+                fd->setPredemodDecimation(m);
+            }
+        }
+    }
+    QPixmapCache::clear();
+    viewport()->update();
+}
+
 void PlotView::addPlot(Plot *plot)
 {
     plots.emplace_back(plot);
@@ -145,6 +160,7 @@ void PlotView::addPlot(Plot *plot)
             fd->setPostLpfMethod(static_cast<FrequencyDemod::LpfMethod>(fmLpfMethod));
             fd->setPostLpfCutoff(fmLpfCutoffHz);
             fd->setPostDecimation(fmDecim);
+            fd->setPredemodDecimation(fmPredemodDecim);
         }
     }
     connect(plot, &Plot::repaint, this, &PlotView::repaint);

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -221,6 +221,26 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
     QMenu *plotsMenu = menu.addMenu("Add derived plot");
     auto src = selectedPlot->output();
     auto compatiblePlots = as_range(Plots::plots.equal_range(src->sampleType()));
+    // Shortcut: add sample/amplitude/frequency as a single stacked set.
+    // Only offered when the source is complex<float> (the combo only makes
+    // sense for that sample type — the three creators all assume it).
+    if (src->sampleType() == typeid(std::complex<float>)) {
+        auto trioAction = new QAction(QStringLiteral("Add IQ + AM + FM"), plotsMenu);
+        connect(
+            trioAction, &QAction::triggered,
+            this, [=]() {
+                // Order: sample (IQ) first, amplitude (AM) second, frequency (FM) last
+                addPlot(Plots::samplePlot(src));
+                addPlot(Plots::amplitudePlot(src));
+                addPlot(Plots::frequencyPlot(src));
+                this->zoomSample = clickSample;
+                this->zoomPos = centerX;
+                this->updateView(true);
+            }
+        );
+        plotsMenu->addAction(trioAction);
+        plotsMenu->addSeparator();
+    }
     for (auto p : compatiblePlots) {
         auto plotInfo = p.second;
         auto action = new QAction(QString("Add %1").arg(plotInfo.name), plotsMenu);

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -126,6 +126,6 @@ private:
     int derivedPlotHeight;
     // Latest-applied FM post-demod settings; re-applied when new FM plots are added.
     double fmLpfCutoffHz = 0.0;
-    int    fmLpfMethod = 2; // FrequencyDemod::LpfMethod::EllipticIir
+    int    fmLpfMethod = 0; // FrequencyDemod::LpfMethod::KaiserFir
     int    fmDecim = 1;
 };

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -71,6 +71,10 @@ public slots:
      * Set maximum threads for background tile rendering.
      */
     void setMaxThreads(int threads);
+    // Cutoff (Hz) for the post-demod LPF on every FM plot. 0 disables.
+    void setFmLpfCutoff(double hz);
+    // Block-average decimation factor on every FM plot. 1 disables.
+    void setFmDecimation(int n);
 
 protected:
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -118,4 +122,7 @@ private:
     int sampleToColumn(size_t sample);
     size_t columnToSample(int col);
     int derivedPlotHeight;
+    // Latest-applied FM post-demod settings; re-applied when new FM plots are added.
+    double fmLpfCutoffHz = 0.0;
+    int    fmDecim = 1;
 };

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -73,6 +73,8 @@ public slots:
     void setMaxThreads(int threads);
     // Cutoff (Hz) for the post-demod LPF on every FM plot. 0 disables.
     void setFmLpfCutoff(double hz);
+    // LPF backend (matches FrequencyDemod::LpfMethod).
+    void setFmLpfMethod(int method);
     // Block-average decimation factor on every FM plot. 1 disables.
     void setFmDecimation(int n);
 
@@ -124,5 +126,6 @@ private:
     int derivedPlotHeight;
     // Latest-applied FM post-demod settings; re-applied when new FM plots are added.
     double fmLpfCutoffHz = 0.0;
+    int    fmLpfMethod = 2; // FrequencyDemod::LpfMethod::EllipticIir
     int    fmDecim = 1;
 };

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -22,6 +22,8 @@
 #include <QGraphicsView>
 #include <QPaintEvent>
 
+#include <QTimer>
+
 #include "cursors.h"
 #include "inputsource.h"
 #include "plot.h"
@@ -53,6 +55,10 @@ signals:
     // Echoed after autoTuneFmLpf() picks values, so the dock widgets can
     // be updated to reflect what was applied.
     void fmAutoLpfComputed(double cutoffHz, int predemodM, int postN);
+    // Auto-detected dominant period (seconds) of the visible FM trace.
+    // Emitted after the analysis debounce timer fires. periodSeconds<=0
+    // means "no signal / not enough data".
+    void autoPeriodChanged(double periodSeconds);
 
 public slots:
     void cursorsMoved();
@@ -139,6 +145,11 @@ private:
     int sampleToColumn(size_t sample);
     size_t columnToSample(int col);
     int derivedPlotHeight;
+    // Debounced auto-period analyser: bumped from updateView() and from
+    // every FM-filter setter; fires once after a short idle so we don't
+    // re-scan the visible region on every scroll tick.
+    QTimer *periodTimer = nullptr;
+    void analyzeVisiblePeriod();
     // Latest-applied FM post-demod settings; re-applied when new FM plots are added.
     double fmLpfCutoffHz = 0.0;
     int    fmLpfMethod = 0; // FrequencyDemod::LpfMethod::KaiserFir

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -77,6 +77,8 @@ public slots:
     void setFmLpfMethod(int method);
     // Block-average decimation factor on every FM plot. 1 disables.
     void setFmDecimation(int n);
+    // Pre-demod IQ decimation factor (1 = off).
+    void setFmPredemodDecimation(int m);
 
 protected:
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -128,4 +130,5 @@ private:
     double fmLpfCutoffHz = 0.0;
     int    fmLpfMethod = 0; // FrequencyDemod::LpfMethod::KaiserFir
     int    fmDecim = 1;
+    int    fmPredemodDecim = 1;
 };

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -95,6 +95,9 @@ public slots:
     // sample rate and tuner bandwidth. Applies them and emits
     // fmAutoLpfComputed() so the dock widgets can mirror.
     void autoTuneFmLpf();
+    // Toggle the period analyser. When off, no scan runs and any existing
+    // markers / period label are cleared.
+    void setPeriodAnalysisEnabled(bool enabled);
 
 protected:
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -150,8 +153,10 @@ private:
     int derivedPlotHeight;
     // Debounced auto-period analyser: bumped from updateView() and from
     // every FM-filter setter; fires once after a short idle so we don't
-    // re-scan the visible region on every scroll tick.
+    // re-scan the visible region on every scroll tick. Gated by
+    // periodAnalysisEnabled (off by default).
     QTimer *periodTimer = nullptr;
+    bool   periodAnalysisEnabled = false;
     void analyzeVisiblePeriod();
     // Latest-applied FM post-demod settings; re-applied when new FM plots are added.
     double fmLpfCutoffHz = 0.0;

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -131,7 +131,10 @@ private:
     void emitTimeSelection();
     // Read a single-sample value from a derived plot's source (FM/AM = float,
     // IQ = complex<float>) and format for display in the status bar.
-    QString sampleValueText(Plot *plot, size_t sampleIdx);
+    // rawValueOut, if non-null, also receives the unscaled float used to
+    // place the hover dot on the trace (NaN if no readable value).
+    QString sampleValueText(Plot *plot, size_t sampleIdx,
+                            double *rawValueOut = nullptr);
     void extractSymbols(std::shared_ptr<AbstractSampleSource> src, bool toClipboard);
     void exportSamples(std::shared_ptr<AbstractSampleSource> src);
     template<typename SOURCETYPE> void exportSamples(std::shared_ptr<AbstractSampleSource> src);

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -47,6 +47,9 @@ signals:
      * @param frequency  Frequency offset in Hz corresponding to mouse Y coordinate in spectrogram
      */
     void mousePositionChanged(double time, double frequency);
+    // Echoed after autoTuneFmLpf() picks values, so the dock widgets can
+    // be updated to reflect what was applied.
+    void fmAutoLpfComputed(double cutoffHz, int predemodM, int postN);
 
 public slots:
     void cursorsMoved();
@@ -79,6 +82,10 @@ public slots:
     void setFmDecimation(int n);
     // Pre-demod IQ decimation factor (1 = off).
     void setFmPredemodDecimation(int m);
+    // Pick reasonable LPF cutoff, predemod M, and post N from the current
+    // sample rate and tuner bandwidth. Applies them and emits
+    // fmAutoLpfComputed() so the dock widgets can mirror.
+    void autoTuneFmLpf();
 
 protected:
     void mouseMoveEvent(QMouseEvent *event) override;

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -44,9 +44,12 @@ signals:
     /**
      * Emitted when the mouse moves over the plot area.
      * @param time     Time position in seconds corresponding to mouse X coordinate
-     * @param frequency  Frequency offset in Hz corresponding to mouse Y coordinate in spectrogram
+     * @param frequency  Frequency offset in Hz when the cursor is over the spectrogram (else 0)
+     * @param valueText  Pre-formatted sample-value string when the cursor is over a derived
+     *                   trace plot (e.g. "0.0042" for a float plot, "I=… Q=…" for IQ); empty
+     *                   when over the spectrogram or no readable plot.
      */
-    void mousePositionChanged(double time, double frequency);
+    void mousePositionChanged(double time, double frequency, QString valueText);
     // Echoed after autoTuneFmLpf() picks values, so the dock widgets can
     // be updated to reflect what was applied.
     void fmAutoLpfComputed(double cutoffHz, int predemodM, int postN);
@@ -120,6 +123,9 @@ private:
 
     void addPlot(Plot *plot);
     void emitTimeSelection();
+    // Read a single-sample value from a derived plot's source (FM/AM = float,
+    // IQ = complex<float>) and format for display in the status bar.
+    QString sampleValueText(Plot *plot, size_t sampleIdx);
     void extractSymbols(std::shared_ptr<AbstractSampleSource> src, bool toClipboard);
     void exportSamples(std::shared_ptr<AbstractSampleSource> src);
     template<typename SOURCETYPE> void exportSamples(std::shared_ptr<AbstractSampleSource> src);

--- a/src/samplebuffer.cpp
+++ b/src/samplebuffer.cpp
@@ -36,8 +36,7 @@ SampleBuffer<Tin, Tout>::~SampleBuffer()
 template <typename Tin, typename Tout>
 std::unique_ptr<Tout[]> SampleBuffer<Tin, Tout>::getSamples(size_t start, size_t length)
 {
-    // TODO: base this on the actual history required
-    auto history = std::min(start, (size_t)256);
+    auto history = std::min(start, this->historySize());
     auto samples = src->getSamples(start - history, length + history);
     if (samples == nullptr)
         return nullptr;
@@ -45,7 +44,10 @@ std::unique_ptr<Tout[]> SampleBuffer<Tin, Tout>::getSamples(size_t start, size_t
     auto temp = std::make_unique<Tout[]>(history + length);
     auto dest = std::make_unique<Tout[]>(length);
     QMutexLocker ml(&mutex);
-    work(samples.get(), temp.get(), history + length, start);
+    // Pass the sampleid of the buffer's first sample (start - history), not of
+    // the returned output, so NCO-based transforms like TunerTransform can set
+    // their phase consistently with what they actually mix.
+    work(samples.get(), temp.get(), history + length, start - history);
     memcpy(dest.get(), temp.get() + history, length * sizeof(Tout));
     return dest;
 }

--- a/src/samplebuffer.h
+++ b/src/samplebuffer.h
@@ -47,4 +47,9 @@ public:
     float relativeBandwidth() {
         return src->relativeBandwidth();
     }
+    // Number of pre-history samples getSamples() fetches and discards so
+    // subclasses can warm their internal filters before producing real output.
+    // Override if a transform needs more than the default 256-sample lead-in
+    // (e.g., a long FIR whose impulse response exceeds it).
+    virtual size_t historySize() { return 256; }
 };

--- a/src/samplebuffer.h
+++ b/src/samplebuffer.h
@@ -27,10 +27,12 @@
 template <typename Tin, typename Tout>
 class SampleBuffer : public SampleSource<Tout>, public Subscriber
 {
-private:
-    std::shared_ptr<SampleSource<Tin>> src;
-
 protected:
+    // Upstream source. Exposed to subclasses so they can override
+    // getSamples and pull a different range (e.g. a batched window for
+    // non-composable filters like IIR filtfilt) without going through the
+    // standard per-tile work() pattern.
+    std::shared_ptr<SampleSource<Tin>> src;
     // Protects work() state (and, by extension, anything work() reads).
     // Setters in subclasses that mutate that state should lock this mutex
     // too so they can't race with scans running on worker threads.

--- a/src/samplebuffer.h
+++ b/src/samplebuffer.h
@@ -29,6 +29,11 @@ class SampleBuffer : public SampleSource<Tout>, public Subscriber
 {
 private:
     std::shared_ptr<SampleSource<Tin>> src;
+
+protected:
+    // Protects work() state (and, by extension, anything work() reads).
+    // Setters in subclasses that mutate that state should lock this mutex
+    // too so they can't race with scans running on worker threads.
     QMutex mutex;
 
 public:

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -242,9 +242,16 @@ void SpectrogramControls::setDefaults()
     annoLabelCheckBox->setCheckState(Qt::Checked);
     annoColorCheckBox->setCheckState(Qt::Checked);
 
-    // Try to set the sample rate from the last-used value
+    // Try to set the sample rate from the last-used value. Sanity-check the
+    // loaded value: a missing/zero setting means "no useful rate was ever
+    // saved", in which case fall back to 8 MHz rather than starting at 0
+    // (FrequencyDemod skips its Hz scaling at rate=0, but downstream UI
+    // — time scale, hover, period analyser — are all degraded with rate=0,
+    // and an obvious sane default lets the user see something instead of a
+    // flat trace).
     QSettings settings;
     int savedSampleRate = settings.value("SampleRate", 8000000).toInt();
+    if (savedSampleRate <= 0) savedSampleRate = 8000000;
     sampleRate->setText(QString::number(savedSampleRate));
     fftSizeSlider->setValue(settings.value("FFTSize", 9).toInt());
     powerMaxSlider->setValue(settings.value("PowerMax", 0).toInt());

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -132,10 +132,10 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     // Kaiser FIR is still available for A/B comparison against the IIR
     // alternatives. Order here must match FrequencyDemod::LpfMethod.
     fmLpfMethodCombo = new QComboBox(widget);
-    fmLpfMethodCombo->addItem(tr("Kaiser FIR (slow)"));
-    fmLpfMethodCombo->addItem(tr("Butterworth IIR"));
-    fmLpfMethodCombo->addItem(tr("Elliptic IIR"));
-    fmLpfMethodCombo->setCurrentIndex(2); // default = Elliptic, matches demod default
+    fmLpfMethodCombo->addItem(tr("Kaiser FIR"));
+    fmLpfMethodCombo->addItem(tr("Butterworth IIR (fast, distorts shape)"));
+    fmLpfMethodCombo->addItem(tr("Elliptic IIR (fast, distorts shape)"));
+    fmLpfMethodCombo->setCurrentIndex(0); // default = Kaiser FIR (linear-phase, accurate)
     layout->addRow(new QLabel(tr("FM LPF method:")), fmLpfMethodCombo);
     connect(fmLpfMethodCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             this, &SpectrogramControls::fmLpfMethodChanged);

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -171,6 +171,19 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     connect(fmDecimSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this, &SpectrogramControls::fmDecimChanged);
 
+    // Auto-tune button: ask PlotView to pick reasonable values for cutoff,
+    // predemod M, and post N. PlotView computes from current Fs and tuner
+    // bandwidth, applies via the existing setters, and echoes the values
+    // back via applyAutoLpf so these widgets stay in sync.
+    fmAutoLpfButton = new QPushButton(tr("Auto-tune FM LPF"), widget);
+    fmAutoLpfButton->setToolTip(tr(
+        "Pick reasonable values for FM LPF cutoff, predemod decimation (M), "
+        "and post decimation (N) from the current sample rate and tuner "
+        "bandwidth."));
+    layout->addRow(fmAutoLpfButton);
+    connect(fmAutoLpfButton, &QPushButton::clicked,
+            this, &SpectrogramControls::autoLpfRequested);
+
     widget->setLayout(layout);
     setWidget(widget);
 
@@ -319,4 +332,17 @@ void SpectrogramControls::zoomOut()
 void SpectrogramControls::enableAnnotations(bool enabled) {
     // disable annotation comments checkbox when annotations are disabled
     commentsCheckBox->setEnabled(enabled);
+}
+
+void SpectrogramControls::applyAutoLpf(double cutoffHz, int predemodM, int postN)
+{
+    // Mirror the PlotView-computed values back into the widgets. The
+    // QSpinBox setValue calls fire valueChanged → re-apply via PlotView's
+    // setters; that's idempotent (the setter sees the same value and is
+    // a no-op). For the QLineEdit we have to emit fmLpfChanged manually
+    // because editingFinished doesn't fire on programmatic setText().
+    fmLpfLineEdit->setText(QString::number(cutoffHz, 'f', 0));
+    emit fmLpfChanged(cutoffHz);
+    fmPredemodDecimSpinBox->setValue(predemodM);
+    fmDecimSpinBox->setValue(postN);
 }

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -116,6 +116,11 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
         "from zero-crossings around the trace's mean. Updates as you pan, "
         "zoom or change filter settings."));
     layout->addRow(new QLabel(tr("Auto period:")), autoPeriodLabel);
+    cursorValueLabel = new QLabel(QStringLiteral("—"));
+    cursorValueLabel->setToolTip(tr(
+        "Sample value at the mouse cursor when hovering over a derived "
+        "trace plot. Float for FM/AM/threshold, I+Q+|·| for IQ."));
+    layout->addRow(new QLabel(tr("Cursor value:")), cursorValueLabel);
     derivedPlotHeightSpinBox = new QSpinBox(widget);
     derivedPlotHeightSpinBox->setRange(20, 1000);
     derivedPlotHeightSpinBox->setValue(200);
@@ -364,4 +369,9 @@ void SpectrogramControls::applyAutoPeriod(double periodSeconds)
     autoPeriodLabel->setText(
         QString::fromStdString(formatSIValue(periodSeconds)) + QStringLiteral("s  (")
         + QString::fromStdString(formatSIValue(freq)) + QStringLiteral("Hz)"));
+}
+
+void SpectrogramControls::applyCursorValue(QString text)
+{
+    cursorValueLabel->setText(text.isEmpty() ? QStringLiteral("—") : text);
 }

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -24,6 +24,7 @@
 #include <QSettings>
 #include <QLabel>
 #include <cmath>
+#include <string>
 #include "util.h"
 
 SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent)
@@ -109,6 +110,12 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     // Derived plots settings
     layout->addRow(new QLabel()); // spacer
     layout->addRow(new QLabel(tr("<b>Derived Plots</b>")));
+    autoPeriodLabel = new QLabel(QStringLiteral("—"));
+    autoPeriodLabel->setToolTip(tr(
+        "Auto-detected dominant period of the visible FM trace, estimated "
+        "from zero-crossings around the trace's mean. Updates as you pan, "
+        "zoom or change filter settings."));
+    layout->addRow(new QLabel(tr("Auto period:")), autoPeriodLabel);
     derivedPlotHeightSpinBox = new QSpinBox(widget);
     derivedPlotHeightSpinBox->setRange(20, 1000);
     derivedPlotHeightSpinBox->setValue(200);
@@ -345,4 +352,16 @@ void SpectrogramControls::applyAutoLpf(double cutoffHz, int predemodM, int postN
     emit fmLpfChanged(cutoffHz);
     fmPredemodDecimSpinBox->setValue(predemodM);
     fmDecimSpinBox->setValue(postN);
+}
+
+void SpectrogramControls::applyAutoPeriod(double periodSeconds)
+{
+    if (periodSeconds <= 0.0 || !std::isfinite(periodSeconds)) {
+        autoPeriodLabel->setText(QStringLiteral("—"));
+        return;
+    }
+    const double freq = 1.0 / periodSeconds;
+    autoPeriodLabel->setText(
+        QString::fromStdString(formatSIValue(periodSeconds)) + QStringLiteral("s  (")
+        + QString::fromStdString(formatSIValue(freq)) + QStringLiteral("Hz)"));
 }

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -151,6 +151,18 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
         double hz = fmLpfLineEdit->text().toDouble(&ok);
         if (ok) emit fmLpfChanged(hz);
     });
+    // FM pre-demod IQ decimation factor (M). 1 = off; M>1 routes the chain
+    // through a polyphase decimator → freqdem at Fs/M → LPF at Fs/M → hold.
+    fmPredemodDecimSpinBox = new QSpinBox(widget);
+    fmPredemodDecimSpinBox->setRange(1, 1000);
+    fmPredemodDecimSpinBox->setValue(1);
+    fmPredemodDecimSpinBox->setToolTip(tr(
+        "Decimate the IQ stream by M before the FM demod (IQEngine pattern). "
+        "M=1 disables; M>1 keeps the post-LPF in a numerically clean regime."));
+    layout->addRow(new QLabel(tr("FM predemod decim (M):")), fmPredemodDecimSpinBox);
+    connect(fmPredemodDecimSpinBox,
+            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &SpectrogramControls::fmPredemodDecimChanged);
     // FM post-demod block-average decimation factor. 1 = disabled.
     fmDecimSpinBox = new QSpinBox(widget);
     fmDecimSpinBox->setRange(1, 4096);

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -128,6 +128,24 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     layout->addRow(new QLabel(tr("Threads:")), threadCountSpinBox);
     connect(threadCountSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this, &SpectrogramControls::threadsChanged);
+    // FM post-demod LPF cutoff (Hz). 0 = disabled.
+    fmLpfLineEdit = new QLineEdit(widget);
+    auto fmLpfValidator = new QDoubleValidator(0.0, 1e9, 3, this);
+    fmLpfLineEdit->setValidator(fmLpfValidator);
+    fmLpfLineEdit->setText("0");
+    layout->addRow(new QLabel(tr("FM LPF cutoff (Hz):")), fmLpfLineEdit);
+    connect(fmLpfLineEdit, &QLineEdit::textChanged, this, [this](const QString &t) {
+        bool ok;
+        double hz = t.toDouble(&ok);
+        if (ok) emit fmLpfChanged(hz);
+    });
+    // FM post-demod block-average decimation factor. 1 = disabled.
+    fmDecimSpinBox = new QSpinBox(widget);
+    fmDecimSpinBox->setRange(1, 4096);
+    fmDecimSpinBox->setValue(1);
+    layout->addRow(new QLabel(tr("FM decim (N):")), fmDecimSpinBox);
+    connect(fmDecimSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &SpectrogramControls::fmDecimChanged);
 
     widget->setLayout(layout);
     setWidget(widget);

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -134,9 +134,11 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     fmLpfLineEdit->setValidator(fmLpfValidator);
     fmLpfLineEdit->setText("0");
     layout->addRow(new QLabel(tr("FM LPF cutoff (Hz):")), fmLpfLineEdit);
-    connect(fmLpfLineEdit, &QLineEdit::textChanged, this, [this](const QString &t) {
+    // Fire only on editingFinished (Enter pressed or focus leaves the field)
+    // so we don't rebuild the Kaiser LPF on every keystroke.
+    connect(fmLpfLineEdit, &QLineEdit::editingFinished, this, [this]() {
         bool ok;
-        double hz = t.toDouble(&ok);
+        double hz = fmLpfLineEdit->text().toDouble(&ok);
         if (ok) emit fmLpfChanged(hz);
     });
     // FM post-demod block-average decimation factor. 1 = disabled.

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -128,6 +128,17 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     layout->addRow(new QLabel(tr("Threads:")), threadCountSpinBox);
     connect(threadCountSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this, &SpectrogramControls::threadsChanged);
+    // FM post-demod LPF method. Kept as a picker so the slow-but-accurate
+    // Kaiser FIR is still available for A/B comparison against the IIR
+    // alternatives. Order here must match FrequencyDemod::LpfMethod.
+    fmLpfMethodCombo = new QComboBox(widget);
+    fmLpfMethodCombo->addItem(tr("Kaiser FIR (slow)"));
+    fmLpfMethodCombo->addItem(tr("Butterworth IIR"));
+    fmLpfMethodCombo->addItem(tr("Elliptic IIR"));
+    fmLpfMethodCombo->setCurrentIndex(2); // default = Elliptic, matches demod default
+    layout->addRow(new QLabel(tr("FM LPF method:")), fmLpfMethodCombo);
+    connect(fmLpfMethodCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this, &SpectrogramControls::fmLpfMethodChanged);
     // FM post-demod LPF cutoff (Hz). 0 = disabled.
     fmLpfLineEdit = new QLineEdit(widget);
     auto fmLpfValidator = new QDoubleValidator(0.0, 1e9, 3, this);

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -224,7 +224,8 @@ void SpectrogramControls::fileOpenButtonClicked()
                 "complex<float> file (*.cfile *.cf32 *.fc32);;"
                 "complex<int8> HackRF file (*.cs8 *.sc8 *.c8);;"
                 "complex<int16> Fancy file (*.cs16 *.sc16 *.c16);;"
-                "complex<uint8> RTL-SDR file (*.cu8 *.uc8)"));
+                "complex<uint8> RTL-SDR file (*.cu8 *.uc8);;"
+                "Rohde & Schwarz iq.tar (*.iq.tar)"));
 
     // Try and load a saved state
     {

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -133,8 +133,8 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     // alternatives. Order here must match FrequencyDemod::LpfMethod.
     fmLpfMethodCombo = new QComboBox(widget);
     fmLpfMethodCombo->addItem(tr("Kaiser FIR"));
-    fmLpfMethodCombo->addItem(tr("Butterworth IIR (fast, distorts shape)"));
-    fmLpfMethodCombo->addItem(tr("Elliptic IIR (fast, distorts shape)"));
+    fmLpfMethodCombo->addItem(tr("Butterworth IIR (filtfilt)"));
+    fmLpfMethodCombo->addItem(tr("Elliptic IIR (filtfilt)"));
     fmLpfMethodCombo->setCurrentIndex(0); // default = Kaiser FIR (linear-phase, accurate)
     layout->addRow(new QLabel(tr("FM LPF method:")), fmLpfMethodCombo);
     connect(fmLpfMethodCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -134,7 +134,6 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     fmLpfMethodCombo = new QComboBox(widget);
     fmLpfMethodCombo->addItem(tr("Kaiser FIR"));
     fmLpfMethodCombo->addItem(tr("Butterworth IIR (filtfilt)"));
-    fmLpfMethodCombo->addItem(tr("Elliptic IIR (filtfilt)"));
     fmLpfMethodCombo->setCurrentIndex(0); // default = Kaiser FIR (linear-phase, accurate)
     layout->addRow(new QLabel(tr("FM LPF method:")), fmLpfMethodCombo);
     connect(fmLpfMethodCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -116,6 +116,15 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
         "from zero-crossings around the trace's mean. Updates as you pan, "
         "zoom or change filter settings."));
     layout->addRow(new QLabel(tr("Auto period:")), autoPeriodLabel);
+    periodAnalysisCheckBox = new QCheckBox(widget);
+    periodAnalysisCheckBox->setCheckState(Qt::Unchecked);
+    periodAnalysisCheckBox->setToolTip(tr(
+        "Run the period analyser and draw peak markers on the FM trace. "
+        "Disabled by default because the markers can be hectic on noisy "
+        "signals."));
+    layout->addRow(new QLabel(tr("Period markers:")), periodAnalysisCheckBox);
+    connect(periodAnalysisCheckBox, &QCheckBox::toggled,
+            this, &SpectrogramControls::periodAnalysisChanged);
     cursorValueLabel = new QLabel(QStringLiteral("—"));
     cursorValueLabel->setToolTip(tr(
         "Sample value at the mouse cursor when hovering over a derived "

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -26,6 +26,7 @@
 #include <QSlider>
 #include <QSpinBox>
 #include <QCheckBox>
+#include <QComboBox>
 #include <QLabel>
 
 class SpectrogramControls : public QDockWidget
@@ -48,6 +49,8 @@ signals:
     void threadsChanged(int threads);
     // Post-demod LPF cutoff (Hz) applied to all frequency plots. 0 = disabled.
     void fmLpfChanged(double hz);
+    // Post-demod LPF implementation (matches FrequencyDemod::LpfMethod).
+    void fmLpfMethodChanged(int method);
     // Block-averaging decimation factor applied after the FM demod. 1 = disabled.
     void fmDecimChanged(int n);
 
@@ -96,6 +99,8 @@ public:
      * Spinbox to select number of threads for concurrent tasks.
      */
     QSpinBox   *threadCountSpinBox;
+    // FM post-demod LPF implementation (Kaiser FIR / Butterworth IIR / Elliptic IIR)
+    QComboBox  *fmLpfMethodCombo;
     // FM post-demod LPF cutoff in Hz (0 disables)
     QLineEdit  *fmLpfLineEdit;
     // FM post-demod block-average decimation factor (1 disables)

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -53,6 +53,9 @@ signals:
     void fmLpfMethodChanged(int method);
     // Block-averaging decimation factor applied after the FM demod. 1 = disabled.
     void fmDecimChanged(int n);
+    // Pre-demod IQ decimation factor (1 = off). When set the FM demod
+    // chain runs at Fs/M (IQEngine pattern).
+    void fmPredemodDecimChanged(int m);
 
 public slots:
     void timeSelectionChanged(float time);
@@ -105,4 +108,6 @@ public:
     QLineEdit  *fmLpfLineEdit;
     // FM post-demod block-average decimation factor (1 disables)
     QSpinBox   *fmDecimSpinBox;
+    // FM pre-demod IQ decimation (1 disables)
+    QSpinBox   *fmPredemodDecimSpinBox;
 };

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -67,6 +67,9 @@ public slots:
     void zoomOut();
     void enableAnnotations(bool enabled);
     void applyAutoLpf(double cutoffHz, int predemodM, int postN);
+    // Show the auto-detected period (in seconds) of the visible FM trace.
+    // periodSeconds <= 0 clears the label (no signal / not enough data).
+    void applyAutoPeriod(double periodSeconds);
 
 private slots:
     void fftSizeChanged(int value);
@@ -95,6 +98,9 @@ public:
     QLabel *periodLabel;
     QLabel *symbolRateLabel;
     QLabel *symbolPeriodLabel;
+    // Auto-detected dominant period of the visible FM trace (zero-crossing
+    // estimate, updated whenever the view or filter changes).
+    QLabel *autoPeriodLabel;
     QCheckBox *scalesCheckBox;
     QCheckBox *annosCheckBox;
     QCheckBox *annoLabelCheckBox;

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -60,6 +60,11 @@ signals:
     // current Fs / tuner bandwidth, applies them, then echoes them back
     // to applyAutoLpf so the dock widgets stay in sync.
     void autoLpfRequested();
+    // Auto-period analysis on/off. Off = no scan, no label, no on-plot
+    // markers. On (default off) = continuous analysis after each view or
+    // filter change, label updates, and triangle/line overlay drawn on
+    // the FM trace.
+    void periodAnalysisChanged(bool enabled);
 
 public slots:
     void timeSelectionChanged(float time);
@@ -104,6 +109,9 @@ public:
     // Auto-detected dominant period of the visible FM trace (zero-crossing
     // estimate, updated whenever the view or filter changes).
     QLabel *autoPeriodLabel;
+    // Toggle for the period analysis (label + on-plot markers). Off by
+    // default — the markers get noisy on broadband signals.
+    QCheckBox *periodAnalysisCheckBox;
     // Sample value at the mouse cursor when hovering a derived plot.
     QLabel *cursorValueLabel;
     QCheckBox *scalesCheckBox;

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -70,6 +70,9 @@ public slots:
     // Show the auto-detected period (in seconds) of the visible FM trace.
     // periodSeconds <= 0 clears the label (no signal / not enough data).
     void applyAutoPeriod(double periodSeconds);
+    // Show the sample value under the cursor when hovering over a derived
+    // plot. Empty string clears the label.
+    void applyCursorValue(QString text);
 
 private slots:
     void fftSizeChanged(int value);
@@ -101,6 +104,8 @@ public:
     // Auto-detected dominant period of the visible FM trace (zero-crossing
     // estimate, updated whenever the view or filter changes).
     QLabel *autoPeriodLabel;
+    // Sample value at the mouse cursor when hovering a derived plot.
+    QLabel *cursorValueLabel;
     QCheckBox *scalesCheckBox;
     QCheckBox *annosCheckBox;
     QCheckBox *annoLabelCheckBox;

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -56,12 +56,17 @@ signals:
     // Pre-demod IQ decimation factor (1 = off). When set the FM demod
     // chain runs at Fs/M (IQEngine pattern).
     void fmPredemodDecimChanged(int m);
+    // User clicked "Auto-tune FM LPF" — PlotView picks values from the
+    // current Fs / tuner bandwidth, applies them, then echoes them back
+    // to applyAutoLpf so the dock widgets stay in sync.
+    void autoLpfRequested();
 
 public slots:
     void timeSelectionChanged(float time);
     void zoomIn();
     void zoomOut();
     void enableAnnotations(bool enabled);
+    void applyAutoLpf(double cutoffHz, int predemodM, int postN);
 
 private slots:
     void fftSizeChanged(int value);
@@ -110,4 +115,6 @@ public:
     QSpinBox   *fmDecimSpinBox;
     // FM pre-demod IQ decimation (1 disables)
     QSpinBox   *fmPredemodDecimSpinBox;
+    // Auto-tune button: PlotView picks reasonable values for cutoff, M, N.
+    QPushButton *fmAutoLpfButton;
 };

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -46,6 +46,10 @@ signals:
      * Requested number of threads to use for tile rendering.
      */
     void threadsChanged(int threads);
+    // Post-demod LPF cutoff (Hz) applied to all frequency plots. 0 = disabled.
+    void fmLpfChanged(double hz);
+    // Block-averaging decimation factor applied after the FM demod. 1 = disabled.
+    void fmDecimChanged(int n);
 
 public slots:
     void timeSelectionChanged(float time);
@@ -92,4 +96,8 @@ public:
      * Spinbox to select number of threads for concurrent tasks.
      */
     QSpinBox   *threadCountSpinBox;
+    // FM post-demod LPF cutoff in Hz (0 disables)
+    QLineEdit  *fmLpfLineEdit;
+    // FM post-demod block-average decimation factor (1 disables)
+    QSpinBox   *fmDecimSpinBox;
 };

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -453,6 +453,16 @@ bool SpectrogramPlot::tunerEnabled()
     return (tunerTransform->subscriberCount() > 0);
 }
 
+void SpectrogramPlot::setTunerCentreY(int y)
+{
+    // Clamp into the plot so the cursors stay visible. The tuner uses
+    // [0..height()] in plot pixels; freq mapping is in getTunerPhaseInc().
+    if (y < 0) y = 0;
+    if (y > height()) y = height();
+    tuner.setCentre(y);
+    tunerMoved();
+}
+
 void SpectrogramPlot::tunerMoved()
 {
     tunerTransform->setFrequency(getTunerPhaseInc());

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -31,6 +31,7 @@
 #include <cstdlib>
 #include <limits>
 #include "util.h"
+#include "latencylog.h"
 
 
 SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>> src) : Plot(src), inputSource(src), fftSize(512), tuner(fftSize, this)
@@ -45,6 +46,15 @@ SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float
     sigmfAnnotationsEnabled = true;
     sigmfAnnotationLabels = true;
     sigmfAnnotationColors = true;
+
+    // Default QCache cost limit is 100. A single wide-zoom view of a long
+    // capture can need 200+ tiles, which means every paint evicts tiles it
+    // just rendered → synchronous FFT recompute on the GUI thread → 200 ms
+    // paints. Each tile pixmap and fft entry is 256 kB (tileSize × 4 B), so
+    // 512 entries gives a ~256 MB combined budget that covers very wide
+    // views with comfortable headroom for pan history.
+    pixmapCache.setMaxCost(512);
+    fftCache.setMaxCost(512);
 
     for (int i = 0; i < 256; i++) {
         float p = (float)i / 256;
@@ -256,6 +266,7 @@ QPixmap* SpectrogramPlot::getPixmapTile(size_t tile)
     if (obj != 0)
         return obj;
 
+    LatencyLog::markf("specgm getPixmapTile MISS tile=%zu (FFT compute+colormap)", tile);
     float *fftTile = getFFTTile(tile);
     obj = new QPixmap(linesPerTile(), fftSize);
     QImage image(linesPerTile(), fftSize, QImage::Format_RGB32);
@@ -272,6 +283,7 @@ QPixmap* SpectrogramPlot::getPixmapTile(size_t tile)
     }
     obj->convertFromImage(image);
     pixmapCache.insert(TileCacheKey(fftSize, zoomLevel, nfftSkip, tile), obj);
+    LatencyLog::markf("specgm getPixmapTile DONE tile=%zu", tile);
     return obj;
 }
 
@@ -465,17 +477,48 @@ void SpectrogramPlot::setTunerCentreY(int y)
 
 void SpectrogramPlot::tunerMoved()
 {
-    tunerTransform->setFrequency(getTunerPhaseInc());
-    tunerTransform->setTaps(getTunerTaps());
+    LatencyLog::mark("tunerMoved start");
+    const float newFreq = getTunerPhaseInc();
+    tunerTransform->setFrequency(newFreq);
+
+    // Tap design is the dominant per-event cost during a tuner drag
+    // (liquid_firdes_kaiser scales with filter length, which gets large at
+    // narrow cutoffs). The taps only depend on deviation/fftSize/powerMax —
+    // pure centre-frequency moves don't touch any of those, so the same
+    // taps are valid and we can skip the redesign + setTaps mutex round.
+    const int   dev   = tuner.deviation();
+    const int   fft_  = fftSize;
+    const float pmax_ = powerMax;
+    bool tapsRebuilt = false;
+    if (dev != lastTapsDeviation_ || fft_ != lastTapsFftSize_ ||
+        pmax_ != lastTapsPowerMax_) {
+        tunerTransform->setTaps(getTunerTaps());
+        lastTapsDeviation_ = dev;
+        lastTapsFftSize_   = fft_;
+        lastTapsPowerMax_  = pmax_;
+        tapsRebuilt = true;
+    }
+
     tunerTransform->setRelativeBandwith(tuner.deviation() * 2.0 / height());
 
-    // Propagate the change through the subscriber chain. Downstream demods
-    // invalidate their plots, which reschedule the min/max scan and bump
-    // tile cache epochs so stale-scaled output isn't shown until the user
-    // happens to scroll.
-    tunerTransform->notifyChanged();
-    QPixmapCache::clear();
+    // Skip the invalidate fan-out when nothing the downstream chain cares
+    // about actually moved. The Tuner emits `tunerMoved` on every mouse
+    // event during drag and on release; many of those events leave
+    // (frequency, deviation) unchanged (mouse release in the same pixel,
+    // duplicate moves while still being processed). Without this guard
+    // every spurious emit triggers a full demod re-render and burns a
+    // worker cycle.
+    const bool notifyNeeded = tapsRebuilt ||
+                              newFreq != lastNotifiedFrequency_ ||
+                              dev     != lastNotifiedDeviation_;
+    if (notifyNeeded) {
+        lastNotifiedFrequency_ = newFreq;
+        lastNotifiedDeviation_ = dev;
+        tunerTransform->notifyChanged();
+    }
 
+    LatencyLog::markf("tunerMoved end (taps_rebuilt=%d notify=%d)",
+                      tapsRebuilt ? 1 : 0, notifyNeeded ? 1 : 0);
     emit repaint();
 }
 

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -459,7 +459,11 @@ void SpectrogramPlot::tunerMoved()
     tunerTransform->setTaps(getTunerTaps());
     tunerTransform->setRelativeBandwith(tuner.deviation() * 2.0 / height());
 
-    // TODO: for invalidating traceplot cache, this shouldn't really go here
+    // Propagate the change through the subscriber chain. Downstream demods
+    // invalidate their plots, which reschedule the min/max scan and bump
+    // tile cache epochs so stale-scaled output isn't shown until the user
+    // happens to scroll.
+    tunerTransform->notifyChanged();
     QPixmapCache::clear();
 
     emit repaint();

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -50,6 +50,11 @@ public:
     std::shared_ptr<SampleSource<std::complex<float>>> input() { return inputSource; };
     void setSampleRate(double sampleRate);
     bool tunerEnabled();
+    // Move the tuner so its centre frequency matches the given y-coordinate
+    // in plot pixels (top of plot = 0, bottom = height()). Used by the right-
+    // click "Add derived plot" menu so the new plot tunes to where the user
+    // clicked instead of leaving the tuner at its previous position.
+    void setTunerCentreY(int y);
     void enableScales(bool enabled);
     void enableAnnotations(bool enabled);
     void enableAnnoLabels(bool enabled);

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -30,6 +30,7 @@
 
 #include <memory>
 #include <array>
+#include <limits>
 #include <math.h>
 #include <vector>
 
@@ -95,6 +96,22 @@ private:
 
     Tuner tuner;
     std::shared_ptr<TunerTransform> tunerTransform;
+
+    // Tap-design memo: liquid_firdes_kaiser is the dominant per-frame cost
+    // during a tuner drag (an O(N²) Bessel evaluation for narrow cutoffs)
+    // but only depends on the inputs below — pure centre-frequency drags
+    // don't change them, so we skip the redesign entirely when nothing's
+    // moved. -1 sentinel forces a fresh design on the first call.
+    int   lastTapsDeviation_ = -1;
+    int   lastTapsFftSize_   = -1;
+    float lastTapsPowerMax_  = std::numeric_limits<float>::quiet_NaN();
+    // Track the (frequency, deviation) the downstream chain was last told
+    // about so we can skip the invalidate fan-out when neither actually
+    // moved. Prevents Tuner::tunerMoved emits with no real change (e.g.
+    // mouse release within the same pixel after a drag) from triggering
+    // a full demod re-render and worker churn.
+    float lastNotifiedFrequency_ = std::numeric_limits<float>::quiet_NaN();
+    int   lastNotifiedDeviation_ = -1;
 
     QPixmap* getPixmapTile(size_t tile);
     float* getFFTTile(size_t tile);

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -130,6 +130,53 @@ void TracePlot::paintFront(QPainter &painter, QRect &rect, range_t<size_t> /*sam
     painter.restore();
 }
 
+static QPair<double,double> scanFloatRange(SampleSource<float> *src, range_t<size_t> range)
+{
+    size_t count = range.maximum - range.minimum;
+    QPair<double,double> result{
+        std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity()};
+    auto data = src->getSamples(range.minimum, count);
+    if (data) {
+        for (size_t i = 0; i < count; ++i) {
+            double v = data[i];
+            if (v < result.first)  result.first  = v;
+            if (v > result.second) result.second = v;
+        }
+    }
+    return result;
+}
+
+static QPair<double,double> scanComplexRange(SampleSource<std::complex<float>> *src, range_t<size_t> range)
+{
+    size_t count = range.maximum - range.minimum;
+    QPair<double,double> result{
+        std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity()};
+    auto data = src->getSamples(range.minimum, count);
+    if (data) {
+        for (size_t i = 0; i < count; ++i) {
+            double re = data[i].real();
+            double im = data[i].imag();
+            if (re < result.first)  result.first  = re;
+            if (im < result.first)  result.first  = im;
+            if (re > result.second) result.second = re;
+            if (im > result.second) result.second = im;
+        }
+    }
+    return result;
+}
+
+void TracePlot::applyMinMax(QPair<double,double> result)
+{
+    if (!std::isfinite(result.first) || !std::isfinite(result.second)) return;
+    bool changed = (globalMin != result.first) || (globalMax != result.second);
+    globalMin = result.first;
+    globalMax = result.second;
+    if (globalMax <= globalMin) globalMax = globalMin + 1.0;
+    if (changed) ++minMaxEpoch;
+}
+
 void TracePlot::scheduleMinMaxIfNeeded(range_t<size_t> sampleRange)
 {
     bool rangeChanged = firstMinMax ||
@@ -138,45 +185,34 @@ void TracePlot::scheduleMinMaxIfNeeded(range_t<size_t> sampleRange)
             (minMaxRange.maximum - minMaxRange.minimum);
     if (!rangeChanged || minMaxWatcher->isRunning())
         return;
+    const bool wasFirst = firstMinMax;
     minMaxRange = sampleRange;
     firstMinMax = false;
+
+    // On the very first paint of a plot, compute min/max synchronously so the
+    // display has valid axis bounds on frame 1. The alternative — default
+    // (0, 1) bounds while the async scan runs — clamps signals like FM (±1e6)
+    // to the plot edges, making the plot look empty. For subsequent paints,
+    // keep the scan async to stay responsive during scrolling.
+    if (wasFirst) {
+        if (auto srcF = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
+            applyMinMax(scanFloatRange(srcF, sampleRange));
+        } else if (auto srcC = dynamic_cast<SampleSource<std::complex<float>>*>(sampleSource.get())) {
+            applyMinMax(scanComplexRange(srcC, sampleRange));
+        }
+        return;
+    }
+
     auto rangeCopy = sampleRange;
     if (auto srcF = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
         auto srcPtr = srcF;
         minMaxWatcher->setFuture(QtConcurrent::run([srcPtr, rangeCopy]() {
-            size_t count = rangeCopy.maximum - rangeCopy.minimum;
-            QPair<double,double> result{
-                std::numeric_limits<double>::infinity(),
-                -std::numeric_limits<double>::infinity()};
-            auto data = srcPtr->getSamples(rangeCopy.minimum, count);
-            if (data) {
-                for (size_t i = 0; i < count; ++i) {
-                    double v = data[i];
-                    if (v < result.first)  result.first  = v;
-                    if (v > result.second) result.second = v;
-                }
-            }
-            return result;
+            return scanFloatRange(srcPtr, rangeCopy);
         }));
     } else if (auto srcC = dynamic_cast<SampleSource<std::complex<float>>*>(sampleSource.get())) {
         auto srcPtr = srcC;
         minMaxWatcher->setFuture(QtConcurrent::run([srcPtr, rangeCopy]() {
-            size_t count = rangeCopy.maximum - rangeCopy.minimum;
-            QPair<double,double> result{
-                std::numeric_limits<double>::infinity(),
-                -std::numeric_limits<double>::infinity()};
-            auto data = srcPtr->getSamples(rangeCopy.minimum, count);
-            if (data) {
-                for (size_t i = 0; i < count; ++i) {
-                    double re = data[i].real();
-                    double im = data[i].imag();
-                    if (re < result.first)  result.first  = re;
-                    if (im < result.first)  result.first  = im;
-                    if (re > result.second) result.second = re;
-                    if (im > result.second) result.second = im;
-                }
-            }
-            return result;
+            return scanComplexRange(srcPtr, rangeCopy);
         }));
     }
 }
@@ -409,17 +445,6 @@ void TracePlot::schedulePendingTiles()
 // Slot: global min/max computed in background
 void TracePlot::onMinMaxReady()
 {
-    auto p = minMaxWatcher->result();
-    bool changed = (globalMin != p.first) || (globalMax != p.second);
-    globalMin = p.first;
-    globalMax = p.second;
-    // ensure non-zero range
-    if (globalMax <= globalMin) globalMax = globalMin + 1.0;
-    if (changed) {
-        // Invalidate cached complex tiles: they were drawn against a stale range.
-        // Incrementing the epoch changes future cache keys so old entries become
-        // unreachable (and get evicted by QPixmapCache over time).
-        ++minMaxEpoch;
-    }
+    applyMinMax(minMaxWatcher->result());
     emit repaint();
 }

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -74,7 +74,23 @@ bool TracePlot::wheelEvent(QWheelEvent *event)
     return false;
 }
 
-void TracePlot::paintFront(QPainter &painter, QRect &rect, range_t<size_t> /*sampleRange*/)
+void TracePlot::setHoverCursor(bool active, size_t sampleIdx,
+                               double value, QString valueText)
+{
+    hoverActive_ = active;
+    hoverSample_ = sampleIdx;
+    hoverValue_  = value;
+    hoverText_   = std::move(valueText);
+    emit repaint();
+}
+
+void TracePlot::setPeriodMarkers(std::vector<size_t> peakSamples)
+{
+    periodMarkers_ = std::move(peakSamples);
+    emit repaint();
+}
+
+void TracePlot::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     // Draw a left-margin y-axis (min / mid / max) and a dashed zero line when
     // zero is within the currently-displayed range. Values come from the shared
@@ -129,6 +145,89 @@ void TracePlot::paintFront(QPainter &painter, QRect &rect, range_t<size_t> /*sam
     painter.drawText(x, rect.top() + fm.ascent() + 1, sMax);
     painter.drawText(x, rect.top() + rect.height() / 2 + fm.ascent() / 2 - 1, sMid);
     painter.drawText(x, rect.bottom() - fm.descent() - 1, sMin);
+
+    // Sample-to-pixel mapping for the marker overlays.
+    auto sampleToX = [&](size_t s) -> int {
+        if (sampleRange.maximum <= sampleRange.minimum) return rect.left();
+        double t = (static_cast<double>(s) - sampleRange.minimum) /
+                   (sampleRange.maximum - sampleRange.minimum);
+        return rect.left() + static_cast<int>(t * rect.width());
+    };
+    auto valueToY = [&](double v) -> int {
+        // Inverse of paintMid's mapping: y = mid + (mid - v) / (visibleSpan/2) * H/2
+        double normalised = (v - mid) / (visibleSpan * 0.5);  // [-1, 1]
+        return rect.y() + static_cast<int>((1.0 - normalised) * (rect.height() * 0.5));
+    };
+
+    // Period markers: small upward triangle at each peak that's in view, plus
+    // a horizontal line connecting consecutive in-view peaks at the trace's
+    // top so the user can see the period span at a glance. Skip cleanly when
+    // there are < 2 in-view markers.
+    if (periodMarkers_.size() >= 2) {
+        QPen markerPen(QColor(255, 200, 0, 220), 1);
+        painter.setPen(markerPen);
+        const int triH = 6;
+        const int yLine = rect.top() + 3;
+        int prevX = -1;
+        for (size_t s : periodMarkers_) {
+            if (s < sampleRange.minimum || s >= sampleRange.maximum) continue;
+            int mx = sampleToX(s);
+            // Triangle pointing down from yLine
+            QPolygon tri;
+            tri << QPoint(mx, yLine + triH)
+                << QPoint(mx - triH/2, yLine)
+                << QPoint(mx + triH/2, yLine);
+            painter.setBrush(QColor(255, 200, 0, 220));
+            painter.drawPolygon(tri);
+            painter.setBrush(Qt::NoBrush);
+            // Vertical guide down to the trace area
+            painter.setPen(QPen(QColor(255, 200, 0, 60), 1, Qt::DashLine));
+            painter.drawLine(mx, yLine + triH, mx, rect.bottom());
+            painter.setPen(markerPen);
+            // Connecting line to the previous in-view peak at the marker row
+            if (prevX >= 0) {
+                painter.drawLine(prevX, yLine + triH, mx, yLine + triH);
+            }
+            prevX = mx;
+        }
+    }
+
+    // Hover-cursor overlay: vertical line at the cursor's sample, small
+    // filled dot at the data value, and the value text in a translucent
+    // pill (placed above or below the dot to stay on-screen).
+    if (hoverActive_ &&
+        hoverSample_ >= sampleRange.minimum &&
+        hoverSample_ <  sampleRange.maximum)
+    {
+        const int cx = sampleToX(hoverSample_);
+        // Vertical guide
+        painter.setPen(QPen(QColor(120, 220, 255, 180), 1, Qt::DashLine));
+        painter.drawLine(cx, rect.top(), cx, rect.bottom());
+        // Dot at the sample value (only if the value is finite and in range)
+        if (std::isfinite(hoverValue_)) {
+            int cy = valueToY(hoverValue_);
+            cy = std::max(rect.top(), std::min(rect.bottom(), cy));
+            painter.setPen(Qt::NoPen);
+            painter.setBrush(QColor(120, 220, 255, 230));
+            painter.drawEllipse(QPoint(cx, cy), 3, 3);
+            painter.setBrush(Qt::NoBrush);
+        }
+        // Text label
+        if (!hoverText_.isEmpty()) {
+            QFontMetrics tm(painter.font());
+            int tw = tm.width(hoverText_);
+            int th = tm.height();
+            int pad = 3;
+            int tx = cx + 6;
+            // Flip to the left if running off the right edge
+            if (tx + tw + 2 * pad > rect.right()) tx = cx - 6 - tw - 2 * pad;
+            int ty = rect.top() + 2;
+            painter.fillRect(tx, ty, tw + 2 * pad, th + 2 * pad,
+                             QColor(0, 0, 0, 180));
+            painter.setPen(QColor(120, 220, 255));
+            painter.drawText(tx + pad, ty + pad + tm.ascent(), hoverText_);
+        }
+    }
 
     painter.restore();
 }

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -20,7 +20,11 @@
 #include <QPixmapCache>
 #include <QTextStream>
 #include <QtConcurrent>
+#include <QThreadPool>
 #include <QPainterPath>
+#include <cmath>
+#include <limits>
+#include <algorithm>
 #include "samplesource.h"
 #include "traceplot.h"
 
@@ -32,34 +36,124 @@ TracePlot::TracePlot(std::shared_ptr<AbstractSampleSource> source) : Plot(source
     debounceTimer->setInterval(50); // ms delay
     connect(debounceTimer, &QTimer::timeout,
             this, &TracePlot::schedulePendingTiles);
+    // vertical zoom scale
+    yScale = 1.0;
+    // initialize min/max background watcher
+    minMaxWatcher = new QFutureWatcher<QPair<double,double>>(this);
+    connect(minMaxWatcher, &QFutureWatcher<QPair<double,double>>::finished,
+            this, &TracePlot::onMinMaxReady);
+    firstMinMax = true;
+}
+
+bool TracePlot::wheelEvent(QWheelEvent *event)
+{
+    // Vertical zoom only for single-channel (float) derived plots
+    if (dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
+        int delta = event->angleDelta().y();
+        // Scale factor: ~1.1x per wheel step
+        double factor = std::pow(1.1, delta / 120.0);
+        yScale *= factor;
+        // Clamp scale
+        yScale = std::max(0.1, std::min(yScale, 10.0));
+        emit repaint();
+        return true;
+    }
+    return false;
 }
 
 void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
-    // start a fresh set of needed tiles for this paint pass
+    // For single-channel (float) derived plots, do centralized draw with global min/max
+    if (auto srcF = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
+        size_t start = sampleRange.minimum;
+        size_t len = sampleRange.maximum - sampleRange.minimum;
+        if (len == 0) return;
+        auto samples = srcF->getSamples(start, len);
+        if (!samples) return;
+        // Schedule background global min/max compute if needed
+        if (firstMinMax ||
+            sampleRange.minimum != minMaxRange.minimum ||
+            (sampleRange.maximum - sampleRange.minimum) !=
+                (minMaxRange.maximum - minMaxRange.minimum)) {
+            if (!minMaxWatcher->isRunning()) {
+                minMaxRange = sampleRange;
+                firstMinMax = false;
+                auto srcPtr = srcF;
+                auto rangeCopy = sampleRange;
+                auto future = QtConcurrent::run([srcPtr, rangeCopy]() {
+                    size_t start = rangeCopy.minimum;
+                    size_t count = rangeCopy.maximum - rangeCopy.minimum;
+                    QPair<double,double> result;
+                    result.first = std::numeric_limits<double>::infinity();
+                    result.second = -std::numeric_limits<double>::infinity();
+                    auto data = srcPtr->getSamples(start, count);
+                    if (data) {
+                        for (size_t i = 0; i < count; ++i) {
+                            double v = data[i];
+                            result.first = std::min(result.first, v);
+                            result.second = std::max(result.second, v);
+                        }
+                    }
+                    return result;
+                });
+                minMaxWatcher->setFuture(future);
+            }
+        }
+        // Use last-known global min/max
+        double minv = globalMin;
+        double maxv = globalMax;
+        if (maxv <= minv) { maxv = minv + 1.0; }
+        double mid = 0.5 * (minv + maxv);
+        double invRange = yScale / (maxv - minv);
+        // Down-sample to at most one point per pixel
+        int w = rect.width();
+        int h = height();
+        double xStep = double(w) / double(len);
+        size_t decim = (len > size_t(w)) ? (len + w - 1) / w : 1;
+        QPainterPath path;
+        bool first = true;
+        for (size_t i = 0; i < len; i += decim) {
+            double s = samples[i];
+            double norm = (s - mid) * invRange;
+            norm = clamp(norm, -1.0, 1.0);
+            double x = rect.x() + i * xStep;
+            double y = rect.y() + (1.0 - norm) * (h * 0.5);
+            if (first) { path.moveTo(x, y); first = false; }
+            else       { path.lineTo(x, y); }
+        }
+        // Ensure last sample
+        if (len > 0 && (len - 1) % decim != 0) {
+            size_t i = len - 1;
+            double s = samples[i];
+            double norm = (s - mid) * invRange;
+            norm = clamp(norm, -1.0, 1.0);
+            double x = rect.x() + w - 1;
+            double y = rect.y() + (1.0 - norm) * (h * 0.5);
+            path.lineTo(x, y);
+        }
+        painter.setPen(Qt::green);
+        painter.drawPath(path);
+        return;
+    }
+    // Fallback: raw complex or multi-channel trace uses existing threaded pixmap pipeline
     currentFrameKeys.clear();
-    if (sampleRange.length() == 0) return;
-
-    int samplesPerColumn = std::max(1UL, sampleRange.length() / rect.width());
-    // dynamic tile size to match thread count
+    size_t totalLen = sampleRange.maximum - sampleRange.minimum;
+    if (totalLen == 0) return;
+    int samplesPerColumn = std::max(1UL, totalLen / rect.width());
     int threads = QThreadPool::globalInstance()->maxThreadCount();
     if (threads < 1) threads = 1;
     int tilePx = rect.width() / threads;
     if (tilePx < 1) tilePx = 1;
     int samplesPerTile = tilePx * samplesPerColumn;
     size_t tileID = sampleRange.minimum / samplesPerTile;
-    size_t tileOffset = sampleRange.minimum % samplesPerTile; // Number of samples to skip from first image tile
-    int xOffset = tileOffset / samplesPerColumn; // Number of columns to skip from first image tile
-
-    // Paint first (possibly partial) tile
+    size_t tileOffset = sampleRange.minimum % samplesPerTile;
+    int xOffset = tileOffset / samplesPerColumn;
     // Paint first (possibly partial) tile
     painter.drawPixmap(
         QRect(rect.x(), rect.y(), tilePx - xOffset, height()),
         getTile(tileID++, samplesPerTile, tilePx),
         QRect(xOffset, 0, tilePx - xOffset, height())
     );
-
-    // Paint remaining tiles
     // Paint remaining tiles
     for (int x = tilePx - xOffset; x < rect.right(); x += tilePx) {
         painter.drawPixmap(
@@ -220,4 +314,15 @@ void TracePlot::schedulePendingTiles()
                          key, QRect(0, 0, tilePx, height()), sampleRange);
         tasks.insert(key);
     }
+}
+
+// Slot: global min/max computed in background
+void TracePlot::onMinMaxReady()
+{
+    auto p = minMaxWatcher->result();
+    globalMin = p.first;
+    globalMax = p.second;
+    // ensure non-zero range
+    if (globalMax <= globalMin) globalMax = globalMin + 1.0;
+    emit repaint();
 }

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -61,6 +61,65 @@ bool TracePlot::wheelEvent(QWheelEvent *event)
     return false;
 }
 
+void TracePlot::paintFront(QPainter &painter, QRect &rect, range_t<size_t> /*sampleRange*/)
+{
+    // Draw a left-margin y-axis (min / mid / max) and a dashed zero line when
+    // zero is within the currently-displayed range. Values come from the shared
+    // globalMin/globalMax computed in scheduleMinMaxIfNeeded(); the float path
+    // additionally compresses/expands by yScale, so reflect that here.
+    double minv = globalMin;
+    double maxv = globalMax;
+    if (maxv <= minv) maxv = minv + 1.0;
+    double mid = 0.5 * (minv + maxv);
+    double axisMin = minv;
+    double axisMax = maxv;
+    if (dynamic_cast<SampleSource<float>*>(sampleSource.get()) && yScale > 0.0) {
+        double halfRange = 0.5 * (maxv - minv) / yScale;
+        axisMin = mid - halfRange;
+        axisMax = mid + halfRange;
+    }
+    double visibleSpan = axisMax - axisMin;
+    if (visibleSpan <= 0.0) visibleSpan = 1.0;
+
+    painter.save();
+
+    // Dashed zero line when 0 is visible.
+    if (axisMin < 0.0 && axisMax > 0.0) {
+        double normZero = -2.0 * mid / visibleSpan;
+        int zeroY = rect.y() + static_cast<int>((1.0 - normZero) * (rect.height() * 0.5));
+        QPen zeroPen(QColor(200, 200, 200, 110), 1, Qt::DashLine);
+        painter.setPen(zeroPen);
+        painter.drawLine(rect.left(), zeroY, rect.right(), zeroY);
+    }
+
+    // Left-margin scale with a translucent backdrop so it reads over the trace.
+    QFont f = painter.font();
+    f.setPointSizeF(8.0);
+    painter.setFont(f);
+    QFontMetrics fm(f);
+
+    auto fmt = [](double v) -> QString {
+        if (std::abs(v) < 1e-12) return QStringLiteral("0");
+        return QString::number(v, 'g', 3);
+    };
+    QString sMax = fmt(axisMax);
+    QString sMid = fmt(mid);
+    QString sMin = fmt(axisMin);
+
+    const int textMargin = 4;
+    int maxW = std::max({fm.width(sMax), fm.width(sMid), fm.width(sMin)});
+    int bgW = maxW + textMargin * 2;
+    painter.fillRect(rect.left(), rect.top(), bgW, rect.height(), QColor(0, 0, 0, 140));
+
+    painter.setPen(QColor(220, 220, 220));
+    int x = rect.left() + textMargin;
+    painter.drawText(x, rect.top() + fm.ascent() + 1, sMax);
+    painter.drawText(x, rect.top() + rect.height() / 2 + fm.ascent() / 2 - 1, sMid);
+    painter.drawText(x, rect.bottom() - fm.descent() - 1, sMin);
+
+    painter.restore();
+}
+
 void TracePlot::scheduleMinMaxIfNeeded(range_t<size_t> sampleRange)
 {
     bool rangeChanged = firstMinMax ||

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -153,10 +153,18 @@ void TracePlot::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampl
                    (sampleRange.maximum - sampleRange.minimum);
         return rect.left() + static_cast<int>(t * rect.width());
     };
+    // Mirror paintMid's float-trace mapping exactly: with yScale=1 the
+    // data fills the middle half of the plot, so v=maxv lands at h/4 (not
+    // at the top — the top of the rect is "empty headroom"). Using the
+    // same formula keeps the hover dot on top of the rendered green line
+    // instead of at a different scale.
+    const int plotH = height();
+    const double invRange = (maxv > minv) ? (yScale / (maxv - minv)) : 1.0;
     auto valueToY = [&](double v) -> int {
-        // Inverse of paintMid's mapping: y = mid + (mid - v) / (visibleSpan/2) * H/2
-        double normalised = (v - mid) / (visibleSpan * 0.5);  // [-1, 1]
-        return rect.y() + static_cast<int>((1.0 - normalised) * (rect.height() * 0.5));
+        double norm = (v - mid) * invRange;
+        if (norm >  1.0) norm =  1.0;
+        if (norm < -1.0) norm = -1.0;
+        return rect.y() + static_cast<int>((1.0 - norm) * (plotH * 0.5));
     };
 
     // Period markers: small upward triangle at each peak that's in view, plus

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -140,6 +140,10 @@ static QPair<double,double> scanFloatRange(SampleSource<float> *src, range_t<siz
     if (data) {
         for (size_t i = 0; i < count; ++i) {
             double v = data[i];
+            // Skip NaN/Inf — freqdem's fresh-state output near t=0 can emit
+            // non-finite samples which would poison min/max comparisons
+            // (NaN < x is always false).
+            if (!std::isfinite(v)) continue;
             if (v < result.first)  result.first  = v;
             if (v > result.second) result.second = v;
         }
@@ -158,10 +162,14 @@ static QPair<double,double> scanComplexRange(SampleSource<std::complex<float>> *
         for (size_t i = 0; i < count; ++i) {
             double re = data[i].real();
             double im = data[i].imag();
-            if (re < result.first)  result.first  = re;
-            if (im < result.first)  result.first  = im;
-            if (re > result.second) result.second = re;
-            if (im > result.second) result.second = im;
+            if (std::isfinite(re)) {
+                if (re < result.first)  result.first  = re;
+                if (re > result.second) result.second = re;
+            }
+            if (std::isfinite(im)) {
+                if (im < result.first)  result.first  = im;
+                if (im > result.second) result.second = im;
+            }
         }
     }
     return result;
@@ -241,23 +249,20 @@ void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleR
         size_t decim = (len > size_t(w)) ? (len + w - 1) / w : 1;
         QPainterPath path;
         bool first = true;
-        for (size_t i = 0; i < len; i += decim) {
+        auto addPoint = [&](size_t i, double xCoord) {
             double s = samples[i];
+            if (!std::isfinite(s)) return;
             double norm = (s - mid) * invRange;
             norm = clamp(norm, -1.0, 1.0);
-            double x = rect.x() + i * xStep;
             double y = rect.y() + (1.0 - norm) * (h * 0.5);
-            if (first) { path.moveTo(x, y); first = false; }
-            else       { path.lineTo(x, y); }
+            if (first) { path.moveTo(xCoord, y); first = false; }
+            else       { path.lineTo(xCoord, y); }
+        };
+        for (size_t i = 0; i < len; i += decim) {
+            addPoint(i, rect.x() + i * xStep);
         }
         if (len > 0 && (len - 1) % decim != 0) {
-            size_t i = len - 1;
-            double s = samples[i];
-            double norm = (s - mid) * invRange;
-            norm = clamp(norm, -1.0, 1.0);
-            double x = rect.x() + w - 1;
-            double y = rect.y() + (1.0 - norm) * (h * 0.5);
-            path.lineTo(x, y);
+            addPoint(len - 1, rect.x() + w - 1);
         }
         painter.setPen(Qt::green);
         painter.drawPath(path);

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -29,7 +29,7 @@
 #include "samplesource.h"
 #include "traceplot.h"
 
-#define INSPECTRUM_TRACE_DEBUG 1
+#define INSPECTRUM_TRACE_DEBUG 0
 
 TracePlot::TracePlot(std::shared_ptr<AbstractSampleSource> source) : Plot(source) {
     connect(this, &TracePlot::imageReady, this, &TracePlot::handleImage);

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include "samplesource.h"
 #include "traceplot.h"
+#include "latencylog.h"
 
 #define INSPECTRUM_TRACE_DEBUG 0
 
@@ -53,8 +54,22 @@ void TracePlot::invalidateEvent()
     // Force a fresh min/max scan next paint and unreach cached tiles. We keep
     // the previous globalMin/Max around until the new scan completes so the
     // first post-invalidate frame is at least drawable rather than blank.
+    // Bumping dataEpoch unreaches both the complex-tile cache (key includes
+    // dataEpoch) and the async float image cache (FloatKey carries it), so
+    // we naturally fall through to a re-render on next paint.
+    //
+    // We deliberately bump *only* on real upstream changes here, not on
+    // min/max wobbles — see applyMinMax for the rationale. Successive
+    // tuner positions can produce min/max scans that differ by 1-3% from
+    // pure FIR/cache boundary noise, and re-rendering for those would
+    // cascade for seconds after every release.
     firstMinMax = true;
-    ++minMaxEpoch;
+    ++dataEpoch;
+    // Drop the stale float-trace image so paintMid blanks the plot until
+    // the in-flight worker delivers a fresh one. Showing stale-but-pretty
+    // data during a drag made the user think the worker had stalled — a
+    // brief blank frame is a clearer "we are recomputing" signal.
+    floatHasImage_ = false;
     emit repaint();
 }
 
@@ -298,11 +313,33 @@ void TracePlot::applyMinMax(QPair<double,double> result)
 #endif
         return;
     }
-    bool changed = (globalMin != result.first) || (globalMax != result.second);
-    globalMin = result.first;
-    globalMax = result.second;
-    if (globalMax <= globalMin) globalMax = globalMin + 1.0;
-    if (changed) ++minMaxEpoch;
+    const double newMin = result.first;
+    double newMax = result.second;
+    if (newMax <= newMin) newMax = newMin + 1.0;
+
+    // Tolerance-gate the bump: each render kicks off a scan, and the scan's
+    // result wobbles by tiny float amounts every cycle (different cache
+    // fill boundaries, FIR transient differences). Without a tolerance the
+    // epoch keeps bumping → keeps invalidating the float-trace key → keeps
+    // re-rendering. Net effect: the trace never "settles" after a tuner
+    // drag and the user sees several seconds of churn.
+    //
+    // 1% of the current range is well below visual significance (a 200 px
+    // tall plot would shift by <2 px), so reject sub-tolerance updates and
+    // leave globalMin/Max unchanged so the axis labels match the cached
+    // image's mapping exactly.
+    const double oldRange = std::max(globalMax - globalMin, 1.0);
+    const double tol = std::max(1e-9, oldRange * 0.01);
+    const bool significant = std::abs(newMin - globalMin) > tol ||
+                             std::abs(newMax - globalMax) > tol;
+    if (!significant) return;
+
+    const double prevMin = globalMin, prevMax = globalMax;
+    globalMin = newMin;
+    globalMax = newMax;
+    ++minMaxEpoch;
+    LatencyLog::markf("traceplot[%p] minMax bump epoch=%d (%.4g..%.4g -> %.4g..%.4g)",
+                      (void*)this, minMaxEpoch, prevMin, prevMax, globalMin, globalMax);
 }
 
 void TracePlot::scheduleMinMaxIfNeeded(range_t<size_t> sampleRange)
@@ -313,30 +350,19 @@ void TracePlot::scheduleMinMaxIfNeeded(range_t<size_t> sampleRange)
             (minMaxRange.maximum - minMaxRange.minimum);
     if (!rangeChanged || minMaxWatcher->isRunning())
         return;
-    const bool wasFirst = firstMinMax;
     minMaxRange = sampleRange;
     firstMinMax = false;
 
-    // On the very first paint of a plot, compute min/max synchronously so the
-    // display has valid axis bounds on frame 1. The alternative — default
-    // (0, 1) bounds while the async scan runs — clamps signals like FM (±1e6)
-    // to the plot edges, making the plot look empty. For subsequent paints,
-    // keep the scan async to stay responsive during scrolling.
-    if (wasFirst) {
-#if INSPECTRUM_TRACE_DEBUG
-        qDebug().nospace() << "[TP " << this << "] sync scan range=("
-                           << sampleRange.minimum << ".." << sampleRange.maximum
-                           << ") len=" << (sampleRange.maximum - sampleRange.minimum);
-#endif
-        if (auto srcF = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
-            applyMinMax(scanFloatRange(srcF, sampleRange));
-        } else if (auto srcC = dynamic_cast<SampleSource<std::complex<float>>*>(sampleSource.get())) {
-            applyMinMax(scanComplexRange(srcC, sampleRange));
-        }
-        return;
-    }
-
+    // Always async, including the first scan — a sync scan here means the
+    // GUI thread blocks on getSamples (which can fan out to the FFT-LPF in
+    // FrequencyDemod, hundreds of ms for large views). We accept that the
+    // very first frame after a parameter change uses the previous globalMin/
+    // Max (or the default 0..1 if this plot has never rendered) — the float
+    // image renderer will re-run automatically once the scan finishes via the
+    // minMaxEpoch bump in applyMinMax.
     auto rangeCopy = sampleRange;
+    LatencyLog::markf("traceplot[%p] minMax scan dispatch range=[%zu..%zu)",
+                      (void*)this, rangeCopy.minimum, rangeCopy.maximum);
     if (auto srcF = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
         auto srcPtr = srcF;
         minMaxWatcher->setFuture(QtConcurrent::run([srcPtr, rangeCopy]() {
@@ -356,41 +382,49 @@ void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleR
     // Used for consistent vertical scaling across both paths and across tiles.
     scheduleMinMaxIfNeeded(sampleRange);
 
-    // For single-channel (float) derived plots, do centralized direct draw.
+    // Single-channel (float) derived plots: render to an offscreen QImage on
+    // a worker thread and blit the most recent completed frame here. The GUI
+    // thread never builds the path or pulls samples; pan/zoom/parameter
+    // changes just bump the desired key, and as soon as the in-flight render
+    // finishes we request the latest one. The user sees one slightly stale
+    // frame while the new one renders, and a fresh frame at "as fast as the
+    // worker can complete" rate during a sustained drag.
     if (auto srcF = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
-        size_t start = sampleRange.minimum;
-        size_t len = sampleRange.maximum - sampleRange.minimum;
-        if (len == 0) return;
-        auto samples = srcF->getSamples(start, len);
-        if (!samples) return;
-        double minv = globalMin;
-        double maxv = globalMax;
-        if (maxv <= minv) { maxv = minv + 1.0; }
-        double mid = 0.5 * (minv + maxv);
-        double invRange = yScale / (maxv - minv);
-        int w = rect.width();
-        int h = height();
-        double xStep = double(w) / double(len);
-        size_t decim = (len > size_t(w)) ? (len + w - 1) / w : 1;
-        QPainterPath path;
-        bool first = true;
-        auto addPoint = [&](size_t i, double xCoord) {
-            double s = samples[i];
-            if (!std::isfinite(s)) return;
-            double norm = (s - mid) * invRange;
-            norm = clamp(norm, -1.0, 1.0);
-            double y = rect.y() + (1.0 - norm) * (h * 0.5);
-            if (first) { path.moveTo(xCoord, y); first = false; }
-            else       { path.lineTo(xCoord, y); }
-        };
-        for (size_t i = 0; i < len; i += decim) {
-            addPoint(i, rect.x() + i * xStep);
+        const int w = rect.width();
+        const int h = height();
+        if (w < 1 || h < 1) return;
+        const size_t start = sampleRange.minimum;
+        const size_t len = sampleRange.maximum - sampleRange.minimum;
+
+        FloatKey k{start, len, w, h, yScale, dataEpoch};
+        floatPendingKey_ = k;
+        floatPendingValid_ = true;
+
+        // Only blit when the cached image actually matches the current key.
+        // Showing a stale image during a tuner/zoom drag was misleading —
+        // the user couldn't tell whether the worker was running or stuck,
+        // and an out-of-date trace masquerades as live data. A blank plot
+        // while computation is in flight + an instant fresh frame on
+        // completion is a more honest signal.
+        if (floatHasImage_ && floatImageKey_ == k) {
+            painter.drawImage(rect, floatImage_);
         }
-        if (len > 0 && (len - 1) % decim != 0) {
-            addPoint(len - 1, rect.x() + w - 1);
+
+        const bool needRender = len > 0 &&
+            (!floatHasImage_ || floatImageKey_ != k);
+        if (needRender && !floatRunning_) {
+            double minv = globalMin;
+            double maxv = globalMax;
+            if (maxv <= minv) maxv = minv + 1.0;
+            double mid = 0.5 * (minv + maxv);
+            double invRange = yScale / (maxv - minv);
+            LatencyLog::markf("traceplot[%p] paintMid float: dispatch render len=%zu w=%d",
+                              (void*)this, len, w);
+            startFloatRender(k, mid, invRange);
+        } else if (needRender) {
+            LatencyLog::markf("traceplot[%p] paintMid float: render busy, key shifted",
+                              (void*)this);
         }
-        painter.setPen(Qt::green);
-        painter.drawPath(path);
         return;
     }
     // Fallback: raw complex or multi-channel trace uses threaded pixmap pipeline.
@@ -429,7 +463,7 @@ QPixmap TracePlot::getTile(size_t tileID, size_t sampleCount, int tileWidthPx)
     QString key;
     QTextStream ts(&key);
     ts << "traceplot_" << this << "_" << tileID << "_" << sampleCount
-       << "_" << minMaxEpoch;
+       << "_" << dataEpoch;
     currentFrameKeys.insert(key);
     // if we already have a cached pixmap, return it immediately
     if (QPixmapCache::find(key, &pixmap))
@@ -580,6 +614,91 @@ void TracePlot::schedulePendingTiles()
 // Slot: global min/max computed in background
 void TracePlot::onMinMaxReady()
 {
+    LatencyLog::markf("traceplot[%p] minMax scan ready", (void*)this);
     applyMinMax(minMaxWatcher->result());
+    emit repaint();
+}
+
+// Render a float trace into an offscreen image. Runs on a QtConcurrent
+// worker — the only main-thread state it touches is the SampleSource pointer,
+// which the chain already supports concurrent reads on (the complex tile
+// path has been doing exactly that since this fork landed).
+static QImage renderFloatTrace(SampleSource<float> *src,
+                               size_t start, size_t len, int w, int h,
+                               double mid, double invRange)
+{
+    LatencyLog::markf("renderFloatTrace start src=%p len=%zu w=%d", (void*)src, len, w);
+    QImage image(w, h, QImage::Format_ARGB32);
+    image.fill(Qt::transparent);
+    if (len == 0 || w < 1 || h < 1) return image;
+    auto samples = src->getSamples(start, len);
+    LatencyLog::markf("renderFloatTrace samples_ready src=%p", (void*)src);
+    if (!samples) return image;
+
+    QPainter painter(&image);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(Qt::green);
+
+    QPainterPath path;
+    bool first = true;
+    const double xStep = double(w) / double(len);
+    const size_t decim = (len > size_t(w)) ? (len + w - 1) / w : 1;
+    auto addPoint = [&](size_t i, double xCoord) {
+        double s = samples[i];
+        if (!std::isfinite(s)) return;
+        double norm = (s - mid) * invRange;
+        if (norm >  1.0) norm =  1.0;
+        if (norm < -1.0) norm = -1.0;
+        double y = (1.0 - norm) * (h * 0.5);
+        if (first) { path.moveTo(xCoord, y); first = false; }
+        else       { path.lineTo(xCoord, y); }
+    };
+    for (size_t i = 0; i < len; i += decim) {
+        addPoint(i, i * xStep);
+    }
+    if (len > 0 && (len - 1) % decim != 0) {
+        addPoint(len - 1, w - 1);
+    }
+    painter.drawPath(path);
+    return image;
+}
+
+void TracePlot::startFloatRender(const FloatKey &k, double mid, double invRange)
+{
+    if (!floatWatcher_) {
+        floatWatcher_ = new QFutureWatcher<QImage>(this);
+        connect(floatWatcher_, &QFutureWatcher<QImage>::finished,
+                this, &TracePlot::onFloatImageReady);
+    }
+    auto srcF = dynamic_cast<SampleSource<float>*>(sampleSource.get());
+    if (!srcF) return;
+    floatRunning_ = true;
+    floatRunningKey_ = k;
+    auto kCopy = k;
+    auto srcPtr = srcF;
+    floatWatcher_->setFuture(QtConcurrent::run([srcPtr, kCopy, mid, invRange]() {
+        return renderFloatTrace(srcPtr, kCopy.start, kCopy.len,
+                                kCopy.w, kCopy.h, mid, invRange);
+    }));
+}
+
+void TracePlot::onFloatImageReady()
+{
+    floatImage_ = floatWatcher_->result();
+    floatImageKey_ = floatRunningKey_;
+    floatHasImage_ = true;
+    floatRunning_ = false;
+    LatencyLog::markf("traceplot[%p] onFloatImageReady (back on GUI)", (void*)this);
+    // If the desired view has moved on while we were rendering (pan, zoom,
+    // tuner shift, FM cutoff change, etc.), kick off another render right
+    // away so the worker stays busy and the user gets continuous updates.
+    if (floatPendingValid_ && floatPendingKey_ != floatImageKey_) {
+        double minv = globalMin;
+        double maxv = globalMax;
+        if (maxv <= minv) maxv = minv + 1.0;
+        double mid = 0.5 * (minv + maxv);
+        double invRange = yScale / (maxv - minv);
+        startFloatRender(floatPendingKey_, mid, invRange);
+    }
     emit repaint();
 }

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -17,6 +17,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QDebug>
 #include <QPixmapCache>
 #include <QTextStream>
 #include <QtConcurrent>
@@ -27,6 +28,8 @@
 #include <algorithm>
 #include "samplesource.h"
 #include "traceplot.h"
+
+#define INSPECTRUM_TRACE_DEBUG 1
 
 TracePlot::TracePlot(std::shared_ptr<AbstractSampleSource> source) : Plot(source) {
     connect(this, &TracePlot::imageReady, this, &TracePlot::handleImage);
@@ -177,7 +180,17 @@ static QPair<double,double> scanComplexRange(SampleSource<std::complex<float>> *
 
 void TracePlot::applyMinMax(QPair<double,double> result)
 {
-    if (!std::isfinite(result.first) || !std::isfinite(result.second)) return;
+#if INSPECTRUM_TRACE_DEBUG
+    qDebug().nospace() << "[TP " << this << "] applyMinMax got ("
+                       << result.first << ", " << result.second << ")"
+                       << " current global=(" << globalMin << ", " << globalMax << ")";
+#endif
+    if (!std::isfinite(result.first) || !std::isfinite(result.second)) {
+#if INSPECTRUM_TRACE_DEBUG
+        qDebug() << "[TP" << this << "] applyMinMax REJECTED — non-finite (no valid samples in scan range)";
+#endif
+        return;
+    }
     bool changed = (globalMin != result.first) || (globalMax != result.second);
     globalMin = result.first;
     globalMax = result.second;
@@ -203,6 +216,11 @@ void TracePlot::scheduleMinMaxIfNeeded(range_t<size_t> sampleRange)
     // to the plot edges, making the plot look empty. For subsequent paints,
     // keep the scan async to stay responsive during scrolling.
     if (wasFirst) {
+#if INSPECTRUM_TRACE_DEBUG
+        qDebug().nospace() << "[TP " << this << "] sync scan range=("
+                           << sampleRange.minimum << ".." << sampleRange.maximum
+                           << ") len=" << (sampleRange.maximum - sampleRange.minimum);
+#endif
         if (auto srcF = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
             applyMinMax(scanFloatRange(srcF, sampleRange));
         } else if (auto srcC = dynamic_cast<SampleSource<std::complex<float>>*>(sampleSource.get())) {

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -316,12 +316,11 @@ QPixmap TracePlot::getTile(size_t tileID, size_t sampleCount, int tileWidthPx)
 
 void TracePlot::drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange)
 {
-    // if this tile is no longer part of the current view, abort early
-    if (!currentFrameKeys.contains(key)) {
-        tasks.remove(key);
-        return;
-    }
-    // render into an offscreen image
+    // NOTE: runs on a QtConcurrent worker thread. Do not touch currentFrameKeys
+    // or tasks from here — they live on the GUI thread and QSet isn't
+    // thread-safe. Any early-exit / bookkeeping based on those sets happens in
+    // handleImage() on the GUI thread (at the cost of a potentially wasted
+    // render for tiles that have scrolled out of view).
     QImage image(rect.size(), QImage::Format_ARGB32);
     image.fill(Qt::transparent);
 
@@ -341,34 +340,40 @@ void TracePlot::drawTile(QString key, const QRect &rect, range_t<size_t> sampleR
     // Is it a 2-channel (complex) trace?
     if (auto src = dynamic_cast<SampleSource<std::complex<float>>*>(sampleSource.get())) {
         auto samples = src->getSamples(firstSample, length);
-        if (samples == nullptr)
-            return;
-
-        painter.setPen(Qt::red);
-        plotTrace(painter, rect, reinterpret_cast<float*>(samples.get()), length, 2, mid, invRange);
-        painter.setPen(Qt::blue);
-        plotTrace(painter, rect, reinterpret_cast<float*>(samples.get())+1, length, 2, mid, invRange);
+        if (samples) {
+            painter.setPen(Qt::red);
+            plotTrace(painter, rect, reinterpret_cast<float*>(samples.get()), length, 2, mid, invRange);
+            painter.setPen(Qt::blue);
+            plotTrace(painter, rect, reinterpret_cast<float*>(samples.get())+1, length, 2, mid, invRange);
+        }
 
     // Otherwise is it single channel?
     } else if (auto src = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
         auto samples = src->getSamples(firstSample, length);
-        if (samples == nullptr)
-            return;
-
-        painter.setPen(Qt::green);
-        plotTrace(painter, rect, samples.get(), length, 1, mid, invRange);
+        if (samples) {
+            painter.setPen(Qt::green);
+            plotTrace(painter, rect, samples.get(), length, 1, mid, invRange);
+        }
     } else {
-        throw std::runtime_error("TracePlot::paintMid: Unsupported source type");
+        throw std::runtime_error("TracePlot::drawTile: Unsupported source type");
     }
 
+    // Always emit — handleImage needs to clear the in-flight bookkeeping even
+    // when getSamples returned null (otherwise the tile stays "in flight"
+    // indefinitely and never re-schedules).
     emit imageReady(key, image);
 }
 
 void TracePlot::handleImage(QString key, QImage image)
 {
+    // Worker finished; clear the in-flight bookkeeping on the GUI thread.
+    tasks.remove(key);
+    // If this tile is no longer desired (viewport moved past it while the
+    // worker was running), drop it without caching.
+    if (!currentFrameKeys.contains(key))
+        return;
     auto pixmap = QPixmap::fromImage(image);
     QPixmapCache::insert(key, pixmap);
-    tasks.remove(key);
     emit repaint();
 }
 

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -61,51 +61,75 @@ bool TracePlot::wheelEvent(QWheelEvent *event)
     return false;
 }
 
+void TracePlot::scheduleMinMaxIfNeeded(range_t<size_t> sampleRange)
+{
+    bool rangeChanged = firstMinMax ||
+        sampleRange.minimum != minMaxRange.minimum ||
+        (sampleRange.maximum - sampleRange.minimum) !=
+            (minMaxRange.maximum - minMaxRange.minimum);
+    if (!rangeChanged || minMaxWatcher->isRunning())
+        return;
+    minMaxRange = sampleRange;
+    firstMinMax = false;
+    auto rangeCopy = sampleRange;
+    if (auto srcF = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
+        auto srcPtr = srcF;
+        minMaxWatcher->setFuture(QtConcurrent::run([srcPtr, rangeCopy]() {
+            size_t count = rangeCopy.maximum - rangeCopy.minimum;
+            QPair<double,double> result{
+                std::numeric_limits<double>::infinity(),
+                -std::numeric_limits<double>::infinity()};
+            auto data = srcPtr->getSamples(rangeCopy.minimum, count);
+            if (data) {
+                for (size_t i = 0; i < count; ++i) {
+                    double v = data[i];
+                    if (v < result.first)  result.first  = v;
+                    if (v > result.second) result.second = v;
+                }
+            }
+            return result;
+        }));
+    } else if (auto srcC = dynamic_cast<SampleSource<std::complex<float>>*>(sampleSource.get())) {
+        auto srcPtr = srcC;
+        minMaxWatcher->setFuture(QtConcurrent::run([srcPtr, rangeCopy]() {
+            size_t count = rangeCopy.maximum - rangeCopy.minimum;
+            QPair<double,double> result{
+                std::numeric_limits<double>::infinity(),
+                -std::numeric_limits<double>::infinity()};
+            auto data = srcPtr->getSamples(rangeCopy.minimum, count);
+            if (data) {
+                for (size_t i = 0; i < count; ++i) {
+                    double re = data[i].real();
+                    double im = data[i].imag();
+                    if (re < result.first)  result.first  = re;
+                    if (im < result.first)  result.first  = im;
+                    if (re > result.second) result.second = re;
+                    if (im > result.second) result.second = im;
+                }
+            }
+            return result;
+        }));
+    }
+}
+
 void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
-    // For single-channel (float) derived plots, do centralized draw with global min/max
+    // Shared: kick off background global min/max whenever the range changes.
+    // Used for consistent vertical scaling across both paths and across tiles.
+    scheduleMinMaxIfNeeded(sampleRange);
+
+    // For single-channel (float) derived plots, do centralized direct draw.
     if (auto srcF = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
         size_t start = sampleRange.minimum;
         size_t len = sampleRange.maximum - sampleRange.minimum;
         if (len == 0) return;
         auto samples = srcF->getSamples(start, len);
         if (!samples) return;
-        // Schedule background global min/max compute if needed
-        if (firstMinMax ||
-            sampleRange.minimum != minMaxRange.minimum ||
-            (sampleRange.maximum - sampleRange.minimum) !=
-                (minMaxRange.maximum - minMaxRange.minimum)) {
-            if (!minMaxWatcher->isRunning()) {
-                minMaxRange = sampleRange;
-                firstMinMax = false;
-                auto srcPtr = srcF;
-                auto rangeCopy = sampleRange;
-                auto future = QtConcurrent::run([srcPtr, rangeCopy]() {
-                    size_t start = rangeCopy.minimum;
-                    size_t count = rangeCopy.maximum - rangeCopy.minimum;
-                    QPair<double,double> result;
-                    result.first = std::numeric_limits<double>::infinity();
-                    result.second = -std::numeric_limits<double>::infinity();
-                    auto data = srcPtr->getSamples(start, count);
-                    if (data) {
-                        for (size_t i = 0; i < count; ++i) {
-                            double v = data[i];
-                            result.first = std::min(result.first, v);
-                            result.second = std::max(result.second, v);
-                        }
-                    }
-                    return result;
-                });
-                minMaxWatcher->setFuture(future);
-            }
-        }
-        // Use last-known global min/max
         double minv = globalMin;
         double maxv = globalMax;
         if (maxv <= minv) { maxv = minv + 1.0; }
         double mid = 0.5 * (minv + maxv);
         double invRange = yScale / (maxv - minv);
-        // Down-sample to at most one point per pixel
         int w = rect.width();
         int h = height();
         double xStep = double(w) / double(len);
@@ -121,7 +145,6 @@ void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleR
             if (first) { path.moveTo(x, y); first = false; }
             else       { path.lineTo(x, y); }
         }
-        // Ensure last sample
         if (len > 0 && (len - 1) % decim != 0) {
             size_t i = len - 1;
             double s = samples[i];
@@ -135,7 +158,8 @@ void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleR
         painter.drawPath(path);
         return;
     }
-    // Fallback: raw complex or multi-channel trace uses existing threaded pixmap pipeline
+    // Fallback: raw complex or multi-channel trace uses threaded pixmap pipeline.
+    // Tiles share the same globalMin/globalMax, so amplitude is consistent across edges.
     currentFrameKeys.clear();
     size_t totalLen = sampleRange.maximum - sampleRange.minimum;
     if (totalLen == 0) return;
@@ -169,7 +193,8 @@ QPixmap TracePlot::getTile(size_t tileID, size_t sampleCount, int tileWidthPx)
     // build tile key and mark as desired for this frame
     QString key;
     QTextStream ts(&key);
-    ts << "traceplot_" << this << "_" << tileID << "_" << sampleCount;
+    ts << "traceplot_" << this << "_" << tileID << "_" << sampleCount
+       << "_" << minMaxEpoch;
     currentFrameKeys.insert(key);
     // if we already have a cached pixmap, return it immediately
     if (QPixmapCache::find(key, &pixmap))
@@ -201,6 +226,13 @@ void TracePlot::drawTile(QString key, const QRect &rect, range_t<size_t> sampleR
     auto firstSample = sampleRange.minimum;
     auto length = sampleRange.length();
 
+    // Snapshot the shared global range so every tile renders at the same scale.
+    double minv = globalMin;
+    double maxv = globalMax;
+    if (maxv <= minv) maxv = minv + 1.0;
+    double mid = 0.5 * (minv + maxv);
+    double invRange = 1.0 / (maxv - minv);
+
     // Is it a 2-channel (complex) trace?
     if (auto src = dynamic_cast<SampleSource<std::complex<float>>*>(sampleSource.get())) {
         auto samples = src->getSamples(firstSample, length);
@@ -208,9 +240,9 @@ void TracePlot::drawTile(QString key, const QRect &rect, range_t<size_t> sampleR
             return;
 
         painter.setPen(Qt::red);
-        plotTrace(painter, rect, reinterpret_cast<float*>(samples.get()), length, 2);
+        plotTrace(painter, rect, reinterpret_cast<float*>(samples.get()), length, 2, mid, invRange);
         painter.setPen(Qt::blue);
-        plotTrace(painter, rect, reinterpret_cast<float*>(samples.get())+1, length, 2);
+        plotTrace(painter, rect, reinterpret_cast<float*>(samples.get())+1, length, 2, mid, invRange);
 
     // Otherwise is it single channel?
     } else if (auto src = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
@@ -219,7 +251,7 @@ void TracePlot::drawTile(QString key, const QRect &rect, range_t<size_t> sampleR
             return;
 
         painter.setPen(Qt::green);
-        plotTrace(painter, rect, samples.get(), length, 1);
+        plotTrace(painter, rect, samples.get(), length, 1, mid, invRange);
     } else {
         throw std::runtime_error("TracePlot::paintMid: Unsupported source type");
     }
@@ -235,27 +267,16 @@ void TracePlot::handleImage(QString key, QImage image)
     emit repaint();
 }
 
-void TracePlot::plotTrace(QPainter &painter, const QRect &rect, float *samples, size_t count, int step = 1)
+void TracePlot::plotTrace(QPainter &painter, const QRect &rect, float *samples,
+                          size_t count, int step, double mid, double invRange)
 {
     // Build a path by down-sampling to at most one point per pixel column.
+    // Scaling (mid, invRange) is supplied by the caller so all tiles share one range.
     QPainterPath path;
     const int w = rect.width();
     const int h = rect.height();
     range_t<float> xRange{0.f, float(w - 2)};
     range_t<float> yRange{0.f, float(h - 2)};
-
-    // Compute normalization range
-    double minv = 1.0e6, maxv = -1.0e6;
-    for (size_t i = 0; i < count; ++i) {
-        float s = samples[i * step];
-        if (s < minv) minv = s;
-        if (s > maxv) maxv = s;
-    }
-    double range = maxv - minv;
-    if (range <= 0.0)
-        range = 1.0;
-    double mid = (minv + maxv) * 0.5;
-    double invRange = 1.0 / range;
 
     // Compute x-step per sample
     const double xStep = double(w) / double(count);
@@ -320,9 +341,16 @@ void TracePlot::schedulePendingTiles()
 void TracePlot::onMinMaxReady()
 {
     auto p = minMaxWatcher->result();
+    bool changed = (globalMin != p.first) || (globalMax != p.second);
     globalMin = p.first;
     globalMax = p.second;
     // ensure non-zero range
     if (globalMax <= globalMin) globalMax = globalMin + 1.0;
+    if (changed) {
+        // Invalidate cached complex tiles: they were drawn against a stale range.
+        // Incrementing the epoch changes future cache keys so old entries become
+        // unreachable (and get evicted by QPixmapCache over time).
+        ++minMaxEpoch;
+    }
     emit repaint();
 }

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -45,6 +45,16 @@ TracePlot::TracePlot(std::shared_ptr<AbstractSampleSource> source) : Plot(source
     firstMinMax = true;
 }
 
+void TracePlot::invalidateEvent()
+{
+    // Force a fresh min/max scan next paint and unreach cached tiles. We keep
+    // the previous globalMin/Max around until the new scan completes so the
+    // first post-invalidate frame is at least drawable rather than blank.
+    firstMinMax = true;
+    ++minMaxEpoch;
+    emit repaint();
+}
+
 bool TracePlot::wheelEvent(QWheelEvent *event)
 {
     // Vertical zoom only for single-channel (float) derived plots

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -37,6 +37,7 @@ public:
     TracePlot(std::shared_ptr<AbstractSampleSource> source);
 
     void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
+    void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     std::shared_ptr<AbstractSampleSource> source() { return sampleSource; };
     // Handle vertical zoom via mouse wheel
     bool wheelEvent(QWheelEvent *event) override;

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -45,6 +45,17 @@ public:
     std::shared_ptr<AbstractSampleSource> source() { return sampleSource; };
     // Handle vertical zoom via mouse wheel
     bool wheelEvent(QWheelEvent *event) override;
+    // Set/clear the hover-cursor overlay (vertical line + value label drawn
+    // by paintFront). PlotView sets this on the plot under the mouse, and
+    // clears all others, so only the active plot shows the marker.
+    void setHoverCursor(bool active, size_t sampleIdx,
+                        double value, QString valueText);
+    // Peak markers used by the auto-period analyser. Each entry is an
+    // absolute sample index where a peak was detected; paintFront draws a
+    // small triangle at each peak that's currently in view and a horizontal
+    // line connecting consecutive peaks so the period is visible at a
+    // glance. Pass an empty vector to clear.
+    void setPeriodMarkers(std::vector<size_t> peakSamples);
 
 signals:
     void imageReady(QString key, QImage image);
@@ -84,6 +95,14 @@ private:
     // Width of each tile in pixels
     // default tile width in pixels (fallback)
     const int defaultTileWidth = 1000;
+    // Hover-cursor state — drawn by paintFront on top of the trace.
+    bool         hoverActive_ = false;
+    size_t       hoverSample_ = 0;
+    double       hoverValue_  = 0.0;
+    QString      hoverText_;
+    // Auto-period peak markers (absolute sample indices). Drawn by
+    // paintFront whenever the visible range overlaps with the marker.
+    std::vector<size_t> periodMarkers_;
 
     // Kick off a background global min/max compute if the view has changed.
     void scheduleMinMaxIfNeeded(range_t<size_t> sampleRange);

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -25,6 +25,9 @@
 #include <QTimer>
 #include <QHash>
 #include <QPair>
+#include <QFutureWatcher>
+#include <QtConcurrent>
+#include <QWheelEvent>
 
 class TracePlot : public Plot
 {
@@ -35,6 +38,8 @@ public:
 
     void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     std::shared_ptr<AbstractSampleSource> source() { return sampleSource; };
+    // Handle vertical zoom via mouse wheel
+    bool wheelEvent(QWheelEvent *event) override;
 
 signals:
     void imageReady(QString key, QImage image);
@@ -45,6 +50,8 @@ public slots:
 private slots:
     // Debounce timer expired: schedule all pending tile-draw tasks
     void schedulePendingTiles();
+    // Background min/max for float plots is ready
+    void onMinMaxReady();
 
 private:
     // In-process tile keys
@@ -56,6 +63,16 @@ private:
     QSet<QString> currentFrameKeys;
     // Debounce timer for batching tile requests
     QTimer *debounceTimer;
+    // Scale factor for vertical zoom
+    double yScale = 1.0;
+    // Background worker for global min/max
+    QFutureWatcher<QPair<double,double>> *minMaxWatcher;
+    // Range for which min/max is computed
+    range_t<size_t> minMaxRange;
+    bool firstMinMax;
+    // Last-known global min/max
+    double globalMin = 0.0;
+    double globalMax = 1.0;
     // Width of each tile in pixels
     // default tile width in pixels (fallback)
     const int defaultTileWidth = 1000;

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -68,6 +68,9 @@ private slots:
     void schedulePendingTiles();
     // Background min/max for float plots is ready
     void onMinMaxReady();
+    // Async float-trace renderer finished — swap in the new image and, if the
+    // view has moved on while it ran, kick off another render for the latest key.
+    void onFloatImageReady();
 
 private:
     // In-process tile keys
@@ -89,8 +92,18 @@ private:
     // Last-known global min/max
     double globalMin = 0.0;
     double globalMax = 1.0;
-    // Bumps whenever globalMin/Max change; included in tile cache keys so old
-    // tiles (rendered with a stale scale) become unreachable and get replaced.
+    // Bumped only by invalidateEvent (real upstream data changes — tuner
+    // moved, FM cutoff changed, etc.). Used as the cache-invalidation signal
+    // for both the complex-tile pixmap cache and the float-trace image
+    // cache. Splitting this from any min/max-driven bump means a tiny
+    // scale wobble (3% range shift after a tuner move) doesn't churn the
+    // entire cached render — the user sees the rendered trace, plus axis
+    // labels that paintFront draws live from globalMin/Max each frame.
+    int dataEpoch = 0;
+    // Counter that's bumped on min/max changes; kept for the trace cache
+    // logic that wants to know "did min/max move at all". Currently only
+    // used to drive the LatencyLog message; could be repurposed if the
+    // axis layer ever wants to debounce its own redraw on it.
     int minMaxEpoch = 0;
     // Width of each tile in pixels
     // default tile width in pixels (fallback)
@@ -104,10 +117,40 @@ private:
     // paintFront whenever the visible range overlaps with the marker.
     std::vector<size_t> periodMarkers_;
 
+    // Async float-trace render state. Single-image pipeline: paintMid blits
+    // the last completed image (possibly stale) and requests a new render
+    // whenever the key shifts. Workers run on the global thread pool; we
+    // keep at most one in flight per plot, and as soon as it finishes we
+    // launch the next one if the latest key has moved on.
+    struct FloatKey {
+        size_t   start = 0;
+        size_t   len   = 0;
+        int      w     = 0;
+        int      h     = 0;
+        double   yScale = 1.0;
+        int      epoch = 0;   // mirrors TracePlot::dataEpoch
+        bool operator==(const FloatKey &o) const {
+            return start==o.start && len==o.len && w==o.w && h==o.h
+                && yScale==o.yScale && epoch==o.epoch;
+        }
+        bool operator!=(const FloatKey &o) const { return !(*this == o); }
+    };
+    QImage                       floatImage_;
+    FloatKey                     floatImageKey_{};
+    bool                         floatHasImage_ = false;
+    FloatKey                     floatPendingKey_{};
+    bool                         floatPendingValid_ = false;
+    FloatKey                     floatRunningKey_{};
+    bool                         floatRunning_ = false;
+    QFutureWatcher<QImage>      *floatWatcher_ = nullptr;
+
     // Kick off a background global min/max compute if the view has changed.
     void scheduleMinMaxIfNeeded(range_t<size_t> sampleRange);
     // Update globalMin/Max and bump the epoch on change; skips non-finite inputs.
     void applyMinMax(QPair<double,double> result);
+    // Launch a background render for the given key. Caller must guarantee
+    // floatRunning_ is false.
+    void startFloatRender(const FloatKey &k, double mid, double invRange);
     // Request the pixmap for a given tile (width in pixels drives sample count)
     QPixmap getTile(size_t tileID, size_t sampleCount, int tileWidthPx);
     void drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange);

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -87,6 +87,8 @@ private:
 
     // Kick off a background global min/max compute if the view has changed.
     void scheduleMinMaxIfNeeded(range_t<size_t> sampleRange);
+    // Update globalMin/Max and bump the epoch on change; skips non-finite inputs.
+    void applyMinMax(QPair<double,double> result);
     // Request the pixmap for a given tile (width in pixels drives sample count)
     QPixmap getTile(size_t tileID, size_t sampleCount, int tileWidthPx);
     void drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange);

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -73,12 +73,18 @@ private:
     // Last-known global min/max
     double globalMin = 0.0;
     double globalMax = 1.0;
+    // Bumps whenever globalMin/Max change; included in tile cache keys so old
+    // tiles (rendered with a stale scale) become unreachable and get replaced.
+    int minMaxEpoch = 0;
     // Width of each tile in pixels
     // default tile width in pixels (fallback)
     const int defaultTileWidth = 1000;
 
+    // Kick off a background global min/max compute if the view has changed.
+    void scheduleMinMaxIfNeeded(range_t<size_t> sampleRange);
     // Request the pixmap for a given tile (width in pixels drives sample count)
     QPixmap getTile(size_t tileID, size_t sampleCount, int tileWidthPx);
     void drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange);
-    void plotTrace(QPainter &painter, const QRect &rect, float *samples, size_t count, int step);
+    void plotTrace(QPainter &painter, const QRect &rect, float *samples,
+                   size_t count, int step, double mid, double invRange);
 };

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -38,6 +38,10 @@ public:
 
     void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
+    // When upstream data changes (tuner moved, LPF retuned, etc.) invalidate
+    // our cached min/max so the next paint reschedules the background scan,
+    // and bump the tile-cache epoch so stale complex-path tiles aren't reused.
+    void invalidateEvent() override;
     std::shared_ptr<AbstractSampleSource> source() { return sampleSource; };
     // Handle vertical zoom via mouse wheel
     bool wheelEvent(QWheelEvent *event) override;

--- a/src/tunertransform.cpp
+++ b/src/tunertransform.cpp
@@ -70,3 +70,8 @@ void TunerTransform::setRelativeBandwith(float bandwidth)
     this->bandwidth = bandwidth;
 }
 
+size_t TunerTransform::historySize()
+{
+    return std::max(static_cast<size_t>(256), taps.size());
+}
+

--- a/src/tunertransform.cpp
+++ b/src/tunertransform.cpp
@@ -19,6 +19,7 @@
 
 #include "tunertransform.h"
 #include <liquid/liquid.h>
+#include <QMutexLocker>
 #include "util.h"
 
 TunerTransform::TunerTransform(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src), frequency(0), bandwidth(1.), taps{1.0f}
@@ -53,12 +54,17 @@ void TunerTransform::work(void *input, void *output, int count, size_t sampleid)
 
 void TunerTransform::setFrequency(float frequency)
 {
+    // Serialize with work() — a worker thread may be reading frequency now.
+    QMutexLocker ml(&mutex);
     this->frequency = frequency;
 }
 
 void TunerTransform::setTaps(std::vector<float> taps)
 {
-    this->taps = taps;
+    // Reassigning the vector reallocates storage; concurrent readers in
+    // work() (via firfilt_crcf_create) would otherwise read freed memory.
+    QMutexLocker ml(&mutex);
+    this->taps = std::move(taps);
 }
 
 float TunerTransform::relativeBandwidth() {
@@ -67,11 +73,13 @@ float TunerTransform::relativeBandwidth() {
 
 void TunerTransform::setRelativeBandwith(float bandwidth)
 {
+    QMutexLocker ml(&mutex);
     this->bandwidth = bandwidth;
 }
 
 size_t TunerTransform::historySize()
 {
+    QMutexLocker ml(&mutex);
     return std::max(static_cast<size_t>(256), taps.size());
 }
 

--- a/src/tunertransform.cpp
+++ b/src/tunertransform.cpp
@@ -33,10 +33,22 @@ void TunerTransform::work(void *input, void *output, int count, size_t sampleid)
     auto out = static_cast<std::complex<float>*>(output);
     auto temp = std::make_unique<std::complex<float>[]>(count);
 
+    // Snapshot parameters under the short-hold paramMutex_ and drop it
+    // before the heavy NCO+FIR loop. The base class's `mutex` is also held
+    // here (by SampleBuffer::getSamples), but the GUI-thread setters use
+    // paramMutex_ instead, so they aren't blocked by this work() running.
+    float freqLocal;
+    std::vector<float> tapsLocal;
+    {
+        QMutexLocker ml(&paramMutex_);
+        freqLocal = frequency;
+        tapsLocal = taps;
+    }
+
     // Mix down
     nco_crcf mix = nco_crcf_create(LIQUID_NCO);
-    nco_crcf_set_phase(mix, fmodf(frequency * sampleid, Tau));
-    nco_crcf_set_frequency(mix, frequency);
+    nco_crcf_set_phase(mix, fmodf(freqLocal * sampleid, Tau));
+    nco_crcf_set_frequency(mix, freqLocal);
     nco_crcf_mix_block_down(mix,
                             static_cast<std::complex<float>*>(input),
                             temp.get(),
@@ -44,7 +56,7 @@ void TunerTransform::work(void *input, void *output, int count, size_t sampleid)
     nco_crcf_destroy(mix);
 
     // Filter
-    firfilt_crcf filter = firfilt_crcf_create(taps.data(), taps.size());
+    firfilt_crcf filter = firfilt_crcf_create(tapsLocal.data(), tapsLocal.size());
     for (int i = 0; i < count; i++)
     {
         firfilt_crcf_push(filter, temp[i]);
@@ -55,32 +67,30 @@ void TunerTransform::work(void *input, void *output, int count, size_t sampleid)
 
 void TunerTransform::setFrequency(float frequency)
 {
-    // Serialize with work() — a worker thread may be reading frequency now.
-    QMutexLocker ml(&mutex);
+    QMutexLocker ml(&paramMutex_);
     this->frequency = frequency;
 }
 
 void TunerTransform::setTaps(std::vector<float> taps)
 {
-    // Reassigning the vector reallocates storage; concurrent readers in
-    // work() (via firfilt_crcf_create) would otherwise read freed memory.
-    QMutexLocker ml(&mutex);
+    QMutexLocker ml(&paramMutex_);
     this->taps = std::move(taps);
 }
 
 float TunerTransform::relativeBandwidth() {
+    QMutexLocker ml(&paramMutex_);
     return bandwidth;
 }
 
 void TunerTransform::setRelativeBandwith(float bandwidth)
 {
-    QMutexLocker ml(&mutex);
+    QMutexLocker ml(&paramMutex_);
     this->bandwidth = bandwidth;
 }
 
 size_t TunerTransform::historySize()
 {
-    QMutexLocker ml(&mutex);
+    QMutexLocker ml(&paramMutex_);
     return std::max(static_cast<size_t>(256), taps.size());
 }
 

--- a/src/tunertransform.cpp
+++ b/src/tunertransform.cpp
@@ -20,6 +20,7 @@
 #include "tunertransform.h"
 #include <liquid/liquid.h>
 #include <QMutexLocker>
+#include <cmath>
 #include "util.h"
 
 TunerTransform::TunerTransform(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src), frequency(0), bandwidth(1.), taps{1.0f}
@@ -50,6 +51,15 @@ void TunerTransform::work(void *input, void *output, int count, size_t sampleid)
         firfilt_crcf_execute(filter, &out[i]);
     }
     firfilt_crcf_destroy(filter);
+
+    // Scrub non-finite values so downstream demods don't see NaN/Inf inputs
+    // (which can poison stateful demods like freqdem at t=0 when the filter
+    // output is briefly zero during warmup).
+    for (int i = 0; i < count; ++i) {
+        if (!std::isfinite(out[i].real()) || !std::isfinite(out[i].imag())) {
+            out[i] = std::complex<float>(0.0f, 0.0f);
+        }
+    }
 }
 
 void TunerTransform::setFrequency(float frequency)

--- a/src/tunertransform.cpp
+++ b/src/tunertransform.cpp
@@ -51,15 +51,6 @@ void TunerTransform::work(void *input, void *output, int count, size_t sampleid)
         firfilt_crcf_execute(filter, &out[i]);
     }
     firfilt_crcf_destroy(filter);
-
-    // Scrub non-finite values so downstream demods don't see NaN/Inf inputs
-    // (which can poison stateful demods like freqdem at t=0 when the filter
-    // output is briefly zero during warmup).
-    for (int i = 0; i < count; ++i) {
-        if (!std::isfinite(out[i].real()) || !std::isfinite(out[i].imag())) {
-            out[i] = std::complex<float>(0.0f, 0.0f);
-        }
-    }
 }
 
 void TunerTransform::setFrequency(float frequency)

--- a/src/tunertransform.h
+++ b/src/tunertransform.h
@@ -36,6 +36,10 @@ public:
     void setTaps(std::vector<float> taps);
     void setRelativeBandwith(float bandwidth);
     float relativeBandwidth() override;
+    // Notify subscribers (downstream demods, which cascade to their plots)
+    // that the mix frequency / filter / bandwidth have changed and any
+    // cached data is stale. Called once after a batch of setters.
+    void notifyChanged() { invalidate(); }
     // The FIR is rebuilt from zero state each call, so the lead-in must cover
     // at least the tap count or the first output samples will be attenuated
     // filter transient — visible as noise in downstream demods.

--- a/src/tunertransform.h
+++ b/src/tunertransform.h
@@ -20,11 +20,21 @@
 #pragma once
 
 #include "samplebuffer.h"
+#include <QMutex>
 #include <vector>
 
 class TunerTransform : public SampleBuffer<std::complex<float>, std::complex<float>>
 {
 private:
+    // Tuner parameters get a dedicated short-hold mutex distinct from
+    // SampleBuffer's `mutex`. The base class holds `mutex` for the entire
+    // duration of every work() call (which can be hundreds of ms over a
+    // wide sample range), so reusing it for the GUI-thread setters means
+    // a tuner drag stalls behind in-flight workers — visible in the
+    // latency trace as 300-700 ms tunerMoved hangs. work() snapshots the
+    // params under paramMutex_ at the top and drops the lock immediately;
+    // setters do the same.
+    mutable QMutex paramMutex_;
     float frequency;
     float bandwidth;
     std::vector<float> taps;

--- a/src/tunertransform.h
+++ b/src/tunertransform.h
@@ -36,4 +36,8 @@ public:
     void setTaps(std::vector<float> taps);
     void setRelativeBandwith(float bandwidth);
     float relativeBandwidth() override;
+    // The FIR is rebuilt from zero state each call, so the lead-in must cover
+    // at least the tap count or the first output samples will be attenuated
+    // filter transient — visible as noise in downstream demods.
+    size_t historySize() override;
 };

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "util.h"
+#include <cmath>
 
 std::string formatSIValue(float value)
 {
@@ -31,17 +32,27 @@ std::string formatSIValue(float value)
         { -9,   "n" },
     };
 
+    // Scale by magnitude only; preserve the sign so the result reads
+    // e.g. "-445k" rather than "-4.45e+14n" (negative values are always
+    // < 1.0 and would otherwise trigger the down-scale loop nine times).
+    if (value == 0.0f) {
+        std::stringstream ss;
+        ss << value;
+        return ss.str();
+    }
+    const float sign = std::signbit(value) ? -1.0f : 1.0f;
+    float mag = std::fabs(value);
     int power = 0;
-    while (value < 1.0f && power > -9) {
-        value *= 1e3;
+    while (mag < 1.0f && power > -9) {
+        mag *= 1e3;
         power -= 3;
     }
-    while (value >= 1e3 && power < 9) {
-        value *= 1e-3;
+    while (mag >= 1e3 && power < 9) {
+        mag *= 1e-3;
         power += 3;
     }
     std::stringstream ss;
-    ss << value << prefixes[power];
+    ss << (sign * mag) << prefixes[power];
     return ss.str();
 }
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,13 @@
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+
+find_package(Liquid REQUIRED)
+
+if (NOT CMAKE_CXX_FLAGS)
+    set(CMAKE_CXX_FLAGS "-O2 -ggdb -march=native")
+endif()
+set(CMAKE_CXX_STANDARD 14)
+
+include_directories(${LIQUID_INCLUDES})
+
+add_executable(fm_filter_compare fm_filter_compare.cpp)
+target_link_libraries(fm_filter_compare ${LIQUID_LIBRARIES} m)

--- a/tools/fm_filter_compare.cpp
+++ b/tools/fm_filter_compare.cpp
@@ -1,0 +1,294 @@
+// Standalone offline test harness for the FM post-demod LPF.
+//
+// Reads a Rohde & Schwarz .iq.tar archive directly (mmap'd, same parser as
+// inspectrum), applies the same NCO + Kaiser-FIR tuner + freqdem chain that
+// the GUI uses, then runs a series of post-demod LPF candidates over the
+// freqdem output. Each candidate is timed and its samples saved as raw
+// float32 so we can plot them with the bundled Python script
+// (tools/fm_filter_plot.py) and compare without bouncing through the GUI.
+//
+// Build:
+//   cmake --build build --target fm_filter_compare
+// Run:
+//   ./build/tools/fm_filter_compare <iq.tar> <center_hz> <bw_hz> <out_dir>
+//
+// All intermediate float32 files are written to <out_dir> with names that
+// describe the filter (raw, butter6, ellip8, kaiser_fir, …). The first 1M
+// samples are processed by default — enough to evaluate any audio-rate
+// modulating signal at 10 MHz Fs.
+
+#include <chrono>
+#include <complex>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <vector>
+
+#include <liquid/liquid.h>
+
+namespace {
+
+struct TarEntry {
+    std::string name;
+    size_t off;
+    size_t sz;
+};
+
+static std::vector<TarEntry> parseTar(const uint8_t *data, size_t total)
+{
+    std::vector<TarEntry> entries;
+    size_t pos = 0;
+    while (pos + 512 <= total) {
+        const char *hdr = reinterpret_cast<const char*>(data + pos);
+        bool allZero = true;
+        for (int i = 0; i < 512; ++i) { if (hdr[i]) { allZero = false; break; } }
+        if (allZero) break;
+        const char *nul = static_cast<const char*>(memchr(hdr, 0, 100));
+        size_t nameLen = nul ? static_cast<size_t>(nul - hdr) : 100;
+        std::string name(hdr, nameLen);
+        char szBuf[13];
+        memcpy(szBuf, hdr + 124, 12);
+        szBuf[12] = 0;
+        size_t sz = strtoull(szBuf, nullptr, 8);
+        char typeflag = hdr[156];
+        size_t dataStart = pos + 512;
+        if (typeflag == '0' || typeflag == '\0') {
+            entries.push_back({name, dataStart, sz});
+        }
+        pos = dataStart + ((sz + 511) / 512) * 512;
+    }
+    return entries;
+}
+
+static std::string xmlTag(const std::string &xml, const std::string &tag)
+{
+    size_t s = xml.find("<" + tag);
+    if (s == std::string::npos) return "";
+    s = xml.find('>', s) + 1;
+    size_t e = xml.find("</" + tag, s);
+    if (e == std::string::npos) return "";
+    return xml.substr(s, e - s);
+}
+
+static void saveF32(const std::string &path, const std::vector<float> &v)
+{
+    std::ofstream f(path, std::ios::binary);
+    f.write(reinterpret_cast<const char*>(v.data()),
+            static_cast<std::streamsize>(v.size() * sizeof(float)));
+    fprintf(stderr, "  wrote %s (%zu samples, %.1f MB)\n",
+            path.c_str(), v.size(), v.size() * sizeof(float) / (1024.0 * 1024.0));
+}
+
+template <typename Apply>
+static void runIirCandidate(const std::string &label,
+                            const std::vector<float> &demod,
+                            const std::string &outDir,
+                            iirfilt_rrrf filt,
+                            Apply &&)
+{
+    std::vector<float> y(demod.size());
+    iirfilt_rrrf_reset(filt);
+    auto t0 = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < demod.size(); ++i) {
+        iirfilt_rrrf_execute(filt, demod[i], &y[i]);
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    fprintf(stderr, "  %-22s %7.1f ms\n", label.c_str(), ms);
+    saveF32(outDir + "/" + label + ".f32", y);
+    iirfilt_rrrf_destroy(filt);
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    if (argc < 5) {
+        fprintf(stderr,
+                "Usage: %s <iq.tar> <tuner_center_hz> <tuner_bw_hz> <out_dir> "
+                "[lpf_cutoff_hz=5000] [n_samples=1000000]\n", argv[0]);
+        return 1;
+    }
+    const char *path = argv[1];
+    const double centerHz = std::stod(argv[2]);
+    const double bwHz = std::stod(argv[3]);
+    const std::string outDir = argv[4];
+    const double lpfHz = (argc >= 6) ? std::stod(argv[5]) : 5000.0;
+    const size_t nWanted = (argc >= 7) ? std::stoull(argv[6]) : 1'000'000ULL;
+
+    int fd = ::open(path, O_RDONLY);
+    if (fd < 0) { perror("open"); return 1; }
+    struct stat st{};
+    if (::fstat(fd, &st) != 0) { perror("fstat"); return 1; }
+    void *mm = ::mmap(nullptr, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (mm == MAP_FAILED) { perror("mmap"); return 1; }
+    const uint8_t *base = static_cast<const uint8_t*>(mm);
+
+    auto entries = parseTar(base, st.st_size);
+    const TarEntry *xmlE = nullptr, *dataE = nullptr;
+    for (const auto &e : entries) {
+        if (e.name.size() >= 4 && e.name.compare(e.name.size() - 4, 4, ".xml") == 0) xmlE = &e;
+    }
+    if (!xmlE) { fprintf(stderr, "iq.tar: no xml found\n"); return 1; }
+
+    std::string xml(reinterpret_cast<const char*>(base + xmlE->off), xmlE->sz);
+    const std::string clockStr = xmlTag(xml, "Clock");
+    const std::string dataFn = xmlTag(xml, "DataFilename");
+    const std::string fmtStr = xmlTag(xml, "Format");
+    const std::string dtypeStr = xmlTag(xml, "DataType");
+    const double Fs = std::stod(clockStr);
+    fprintf(stderr, "Fs=%.0f Hz, data=%s, fmt=%s/%s\n",
+            Fs, dataFn.c_str(), fmtStr.c_str(), dtypeStr.c_str());
+
+    for (const auto &e : entries) if (e.name == dataFn) dataE = &e;
+    if (!dataE) { fprintf(stderr, "iq.tar: data file '%s' missing\n", dataFn.c_str()); return 1; }
+    if (fmtStr != "complex" || dtypeStr != "float32") {
+        fprintf(stderr, "Only complex/float32 supported in this tool\n"); return 1;
+    }
+
+    const auto *iq = reinterpret_cast<const std::complex<float>*>(base + dataE->off);
+    const size_t nTotal = dataE->sz / sizeof(std::complex<float>);
+    const size_t N = std::min(nWanted, nTotal);
+    fprintf(stderr, "processing N=%zu of %zu samples (%.3f s)\n",
+            N, nTotal, static_cast<double>(N) / Fs);
+
+    // Tuner: NCO mix down by centerHz, then Kaiser FIR LPF at bwHz/2.
+    nco_crcf nco = nco_crcf_create(LIQUID_NCO);
+    nco_crcf_set_frequency(nco, 2.0f * static_cast<float>(M_PI) *
+                                  static_cast<float>(centerHz / Fs));
+    std::vector<std::complex<float>> mixed(N);
+    nco_crcf_mix_block_down(nco, const_cast<std::complex<float>*>(iq),
+                            mixed.data(), N);
+    nco_crcf_destroy(nco);
+
+    const float tunerCutoff = static_cast<float>((bwHz / 2) / Fs);
+    const float atten = 60.0f;
+    unsigned int tunerLen = estimate_req_filter_len(std::min(tunerCutoff, 0.05f), atten);
+    if (tunerLen < 3) tunerLen = 3;
+    std::vector<float> tunerTaps(tunerLen);
+    liquid_firdes_kaiser(tunerLen, tunerCutoff, atten, 0.0f, tunerTaps.data());
+
+    firfilt_crcf tunerFilt = firfilt_crcf_create(tunerTaps.data(), tunerLen);
+    std::vector<std::complex<float>> tuned(N);
+    for (size_t i = 0; i < N; ++i) {
+        firfilt_crcf_push(tunerFilt, mixed[i]);
+        firfilt_crcf_execute(tunerFilt, &tuned[i]);
+    }
+    firfilt_crcf_destroy(tunerFilt);
+
+    // freqdem: kf matches tuner relative bandwidth.
+    const float relBw = static_cast<float>(bwHz / Fs);
+    freqdem fdem = freqdem_create(relBw / 2.0f);
+    std::vector<float> demod(N);
+    for (size_t i = 0; i < N; ++i) {
+        freqdem_demodulate(fdem, *reinterpret_cast<liquid_float_complex*>(&tuned[i]),
+                           &demod[i]);
+    }
+    freqdem_destroy(fdem);
+
+    fprintf(stderr, "Saving raw demod and filter candidates @ Fc=%.0f Hz:\n", lpfHz);
+    saveF32(outDir + "/raw_demod.f32", demod);
+
+    const float fcNorm = static_cast<float>(lpfHz / Fs);
+
+    // 1) Butterworth IIR (cascaded SOS) — the previous default.
+    runIirCandidate("butter_o6_iir", demod, outDir,
+        iirfilt_rrrf_create_prototype(LIQUID_IIRDES_BUTTER, LIQUID_IIRDES_LOWPASS,
+                                      LIQUID_IIRDES_SOS, 6, fcNorm, 0.0f, 0.1f, 60.0f),
+        nullptr);
+    runIirCandidate("butter_o10_iir", demod, outDir,
+        iirfilt_rrrf_create_prototype(LIQUID_IIRDES_BUTTER, LIQUID_IIRDES_LOWPASS,
+                                      LIQUID_IIRDES_SOS, 10, fcNorm, 0.0f, 0.1f, 60.0f),
+        nullptr);
+
+    // 2) Chebyshev type 2 — flat passband, ripple in stopband (better
+    //    for visualization than type 1 which ripples the passband).
+    runIirCandidate("cheby2_o8_iir", demod, outDir,
+        iirfilt_rrrf_create_prototype(LIQUID_IIRDES_CHEBY2, LIQUID_IIRDES_LOWPASS,
+                                      LIQUID_IIRDES_SOS, 8, fcNorm, 0.0f, 0.1f, 60.0f),
+        nullptr);
+
+    // 3) Elliptic — sharpest transition for a given order; current
+    //    inspectrum default at order 8.
+    runIirCandidate("ellip_o8_iir", demod, outDir,
+        iirfilt_rrrf_create_prototype(LIQUID_IIRDES_ELLIP, LIQUID_IIRDES_LOWPASS,
+                                      LIQUID_IIRDES_SOS, 8, fcNorm, 0.0f, 0.1f, 60.0f),
+        nullptr);
+    runIirCandidate("ellip_o12_iir", demod, outDir,
+        iirfilt_rrrf_create_prototype(LIQUID_IIRDES_ELLIP, LIQUID_IIRDES_LOWPASS,
+                                      LIQUID_IIRDES_SOS, 12, fcNorm, 0.0f, 0.1f, 60.0f),
+        nullptr);
+
+    // Helper to run an FIR over the demod buffer and time it.
+    auto runFir = [&](const std::string &label, unsigned int len) {
+        if (len < 3) len = 3;
+        std::vector<float> taps(len);
+        liquid_firdes_kaiser(len, fcNorm, 60.0f, 0.0f, taps.data());
+        // Normalize to unity DC gain.
+        double dc = 0.0;
+        for (auto t : taps) dc += t;
+        if (dc != 0.0) for (auto &t : taps) t = static_cast<float>(t / dc);
+        firfilt_rrrf fir = firfilt_rrrf_create(taps.data(), len);
+        std::vector<float> y(N);
+        auto t0 = std::chrono::steady_clock::now();
+        for (size_t i = 0; i < N; ++i) {
+            firfilt_rrrf_push(fir, demod[i]);
+            firfilt_rrrf_execute(fir, &y[i]);
+        }
+        auto t1 = std::chrono::steady_clock::now();
+        double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+        firfilt_rrrf_destroy(fir);
+        fprintf(stderr, "  %-22s %7.1f ms (taps=%u, dc_norm)\n", label.c_str(), ms, len);
+        saveF32(outDir + "/" + label + ".f32", y);
+    };
+
+    // 4) Kaiser FIR — full reference (linear-phase, expensive).
+    {
+        unsigned int firLen = estimate_req_filter_len(std::max(fcNorm, 1e-4f), 60.0f);
+        runFir("kaiser_fir", firLen);
+    }
+    // 5) Capped Kaiser FIRs — linear phase but cost bounded, useful for narrow Fc.
+    runFir("kaiser_fir_1024", 1024);
+    runFir("kaiser_fir_4096", 4096);
+
+    // 6) Filtfilt-style zero-phase via forward+reversed IIR. Effective order
+    //    doubles, group delay cancels, magnitude response squared. Cheaper
+    //    than a comparable-length FIR and keeps linear-phase look.
+    {
+        iirfilt_rrrf filt = iirfilt_rrrf_create_prototype(
+            LIQUID_IIRDES_BUTTER, LIQUID_IIRDES_LOWPASS, LIQUID_IIRDES_SOS,
+            6, fcNorm, 0.0f, 0.1f, 60.0f);
+        std::vector<float> y(N);
+        auto t0 = std::chrono::steady_clock::now();
+        // Forward
+        iirfilt_rrrf_reset(filt);
+        for (size_t i = 0; i < N; ++i) iirfilt_rrrf_execute(filt, demod[i], &y[i]);
+        // Reverse pass
+        iirfilt_rrrf_reset(filt);
+        std::vector<float> z(N);
+        for (size_t i = 0; i < N; ++i) {
+            float in = y[N - 1 - i];
+            iirfilt_rrrf_execute(filt, in, &z[N - 1 - i]);
+        }
+        auto t1 = std::chrono::steady_clock::now();
+        iirfilt_rrrf_destroy(filt);
+        double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+        fprintf(stderr, "  %-22s %7.1f ms (zero-phase)\n", "butter_o6_filtfilt", ms);
+        saveF32(outDir + "/butter_o6_filtfilt.f32", z);
+    }
+
+    fprintf(stderr, "done. Plot with:\n"
+            "  python3 tools/fm_filter_plot.py %s/*.f32\n", outDir.c_str());
+
+    ::munmap(mm, st.st_size);
+    ::close(fd);
+    return 0;
+}

--- a/tools/fm_filter_plot.py
+++ b/tools/fm_filter_plot.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Plot raw float32 sample dumps from fm_filter_compare side by side.
+
+Usage:
+  python3 tools/fm_filter_plot.py /tmp/fm_out/*.f32
+
+By default plots the first 200k samples; pass --start / --count to scrub.
+"""
+
+import argparse
+import os
+import sys
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("files", nargs="+", help="float32 sample dumps")
+    ap.add_argument("--start", type=int, default=0)
+    ap.add_argument("--count", type=int, default=200_000)
+    ap.add_argument("--fs", type=float, default=10e6, help="sample rate (Hz)")
+    args = ap.parse_args()
+
+    fig, axes = plt.subplots(len(args.files), 1, figsize=(14, 2.0 * len(args.files)),
+                             sharex=True)
+    if len(args.files) == 1:
+        axes = [axes]
+    for ax, path in zip(axes, args.files):
+        data = np.fromfile(path, dtype=np.float32)
+        end = min(args.start + args.count, len(data))
+        sl = data[args.start:end]
+        t = np.arange(args.start, end) / args.fs
+        ax.plot(t, sl, linewidth=0.5)
+        ax.set_title(os.path.basename(path), fontsize=9)
+        ax.grid(True, alpha=0.3)
+        ax.set_ylabel("value")
+    axes[-1].set_xlabel("time (s)")
+    fig.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Reworks the demod plot pipeline so heavy compute moves off the GUI thread and parameter drags don't block on in-flight workers. Tuner drags went from 100-700 ms `tunerMoved` hangs to <1 ms; average paint dropped from ~200 ms to ~12 ms; the multi-second \"settle\" tail after every retune is gone.

### Bug fixes folded in

- `util::formatSIValue` scales by magnitude and reapplies sign — negatives now render as `-445k` instead of `-4.45e+14n`.
- Derived plots paint into a content-width rect (clamped to `sampleToColumn(viewRange.length())`) so they stop stretching past the spectrogram when the view is wider than the file.
- `FrequencyDemod` skips the m → Hz output scaling when `rate()` is 0, so a bogus saved sample rate doesn't multiply the entire trace by zero.
- `MainWindow` / `SpectrogramControls` refuse to save/load a 0 sample rate — a transient empty text-edit can't poison the next session anymore.
- `MainWindow` parses `gqrx_<date>_<time>_<centerHz>_<rateHz>_fc.raw` filenames and seeds both sample rate and centre frequency.

### Performance pass

- `TracePlot`: async float-trace render. `paintMid` blits the cached image and dispatches a worker if the `FloatKey` shifted; the GUI thread never builds the path or pulls samples.
- `TracePlot`: drop the stale image on invalidate so a tuner drag shows blank-then-fresh instead of stale-then-fresh.
- `TracePlot`: split data-change epoch from min/max scale epoch. `FloatKey` and the complex tile cache key both use `dataEpoch` (real upstream changes only); 1-3% min/max wobbles from FIR boundary noise no longer invalidate cached renders.
- `TracePlot`: 1% tolerance on `applyMinMax` bumps. Min/max scan moved fully async (was sync on the first paint after every invalidate).
- `SpectrogramPlot`: pixmap/fft caches sized 100 → 512 (256 MB combined budget). Wide views previously thrashed the cache and re-FFT'd every tile on every paint — 200+ MISSes per paint, 200 ms paint times.
- `SpectrogramPlot`: cache the Kaiser FIR taps so pure centre-frequency drags skip `liquid_firdes_kaiser` entirely. Drop the `QPixmapCache::clear()` on tuner move and skip the downstream invalidate when neither frequency nor deviation actually moved.
- `TunerTransform`: setters use a dedicated short-hold `paramMutex_` instead of the `SampleBuffer` mutex `work()` holds throughout. GUI-thread setters no longer block behind a worker's NCO+FIR run on millions of samples.
- `FrequencyDemod`: `invalidateBatchCache` is non-blocking now — bumps an atomic `cacheEpoch_` instead of taking `batchMutex_`. Fillers stamp their result with the entry epoch and `getSamples`'s covers check rejects results from older epochs.

### Diagnostics

Adds an opt-in latency tracer (`INSPECTRUM_LAT_LOG=1`) at the hot points along the input → invalidate → render → blit chain. Useful for investigating any remaining stutter.

## Test plan

- [ ] Open a wide IQ capture, add IQ + AM + FM, drag the tuner cursor — no multi-second freezes
- [ ] Drag the tuner with FM LPF cutoff set both at 0 and at e.g. 10 kHz
- [ ] Pan/zoom the spectrogram repeatedly across previously-visited regions — paints should be near-instant after the first warm pass
- [ ] Toggle Kaiser FIR vs Butterworth IIR while a render is in flight — no UI freeze
- [ ] Verify FM hover values format correctly for negative deviations
- [ ] Verify `gqrx_<...>.raw` filenames auto-set sample rate and centre frequency
- [ ] Verify a previously-saved `SampleRate=0` in QSettings doesn't break the FM trace anymore (manual repro: edit `~/.config/inspectrum/inspectrum.conf` to set `SampleRate=0` and relaunch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)