### PR TITLE
FSK/TETRA analysis tooling: symbol-rate constellation, level histogram, robustness fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,8 @@ list(APPEND inspectrum_sources
     main.cpp
     fft.cpp
     frequencydemod.cpp
+    fskdemod.cpp
+    fskpolarplot.cpp
     mainwindow.cpp
     inputsource.cpp
     phasedemod.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND inspectrum_sources
     frequencydemod.cpp
     fskdemod.cpp
     fskpolarplot.cpp
+    histogramplot.cpp
     mainwindow.cpp
     inputsource.cpp
     phasedemod.cpp

--- a/src/amplitudedemod.h
+++ b/src/amplitudedemod.h
@@ -26,4 +26,5 @@ class AmplitudeDemod : public SampleBuffer<std::complex<float>, float>
 public:
     AmplitudeDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
     void work(void *input, void *output, int count, size_t sampleid) override;
+    bool workIsReentrant() override { return true; } // stateless |x|² map
 };

--- a/src/frequencydemod.cpp
+++ b/src/frequencydemod.cpp
@@ -196,6 +196,19 @@ void FrequencyDemod::setPredemodDecimation(int m)
     invalidate();
 }
 
+void FrequencyDemod::setAmplitudeSquelch(double frac)
+{
+    if (frac < 0.0) frac = 0.0;
+    if (frac > 1.0) frac = 1.0;
+    {
+        QMutexLocker ml(&mutex);
+        if (frac == squelchFrac_) return;
+        squelchFrac_ = frac;
+    }
+    invalidateBatchCache();
+    invalidate();
+}
+
 void FrequencyDemod::destroyPostLpf()
 {
     if (postFir_) { firfilt_rrrf_destroy(postFir_); postFir_ = nullptr; }
@@ -394,6 +407,7 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
     size_t    settle;
     bool      cheap;
     int       decim;
+    double    squelch;
     {
         QMutexLocker ml(&mutex);
         method   = postLpfMethod_;
@@ -402,6 +416,7 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
         settle   = lpfSettleSamples_ ? lpfSettleSamples_ : 4096;
         cheap    = cheapMode_;
         decim    = predemodDecim_;
+        squelch  = squelchFrac_;
     }
     if (decim < 1) decim = 1;
 
@@ -596,6 +611,23 @@ bool FrequencyDemod::fillBatchCache(size_t needStart, size_t needEnd)
         for (auto &s : demod) s *= scalef;
     }
 
+    // Amplitude squelch (see work()): blank FM output where |IQ| is below
+    // squelch · window-peak. rawIq is the full-rate IQ, aligned 1:1 with the
+    // (hold-expanded) demod buffer.
+    if (squelch > 0.0 && batchLen > 0) {
+        const std::complex<float> *iqFull = rawIq.get();
+        float peak = 0.0f;
+        for (size_t i = 0; i < batchLen; ++i) {
+            const float a = std::abs(iqFull[i]);
+            if (a > peak) peak = a;
+        }
+        const float thr = peak * static_cast<float>(squelch);
+        for (size_t i = 0; i < batchLen; ++i) {
+            if (std::abs(iqFull[i]) < thr)
+                demod[i] = std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+
     // Small absolute file-start NaN mask for the upstream tuner's FIR
     // cold-start. The bilateral pad above handles *our* LPF, but the
     // tuner runs at full Fs upstream and its output samples [0..tuner_taps]
@@ -763,6 +795,24 @@ void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
                 : (0.49 * r);
             const float scalef = static_cast<float>(scale);
             for (int i = 0; i < count; ++i) out[i] *= scalef;
+        }
+    }
+
+    // Amplitude squelch: blank (NaN) the FM output where the carrier amplitude
+    // |IQ| is below squelchFrac_ · window-peak, so noise in the gaps between
+    // bursts — where the discriminator output is large and wild — doesn't
+    // dominate the autoscale or the trace. NaN is skipped by the min/max scan
+    // and breaks the rendered trace into gaps.
+    if (squelchFrac_ > 0.0 && count > 0) {
+        float peak = 0.0f;
+        for (int i = 0; i < count; ++i) {
+            const float a = std::abs(in[i]);
+            if (a > peak) peak = a;
+        }
+        const float thr = peak * static_cast<float>(squelchFrac_);
+        for (int i = 0; i < count; ++i) {
+            if (std::abs(in[i]) < thr)
+                out[i] = std::numeric_limits<float>::quiet_NaN();
         }
     }
 

--- a/src/frequencydemod.h
+++ b/src/frequencydemod.h
@@ -70,6 +70,11 @@ public:
     // demod and post-LPF at a low rate keeps the post-LPF in a numerically
     // well-conditioned regime and shrinks every filter's tap budget.
     void setPredemodDecimation(int m);
+    // Amplitude squelch as a fraction (0..1) of the window's peak carrier
+    // amplitude |IQ|. Samples below it are blanked to NaN so receiver noise in
+    // the gaps between bursts (where the discriminator output swings wildly)
+    // doesn't dominate the autoscale or the trace. 0 disables.
+    void setAmplitudeSquelch(double frac);
 
 private:
     // Liquid-DSP frequency demodulator object
@@ -99,6 +104,8 @@ private:
     // Pre-demod IQ decimation factor (1 = disabled). When >1 the batched
     // path runs the entire chain at Fs/M.
     int          predemodDecim_ = 1;
+    // Amplitude squelch fraction (0..1) of window-peak |IQ|; 0 = disabled.
+    double       squelchFrac_ = 0.0;
 
     void destroyPostLpf();
     void rebuildPostLpf();

--- a/src/fskdemod.cpp
+++ b/src/fskdemod.cpp
@@ -81,11 +81,22 @@ void FskDemod::work(void *input, void *output, int count, size_t sampleid)
     }
     movingAverage(absCentered, level, kLevelWindow);
 
-    // Peak deviation across the window, used as the squelch reference below.
+    // Peak deviation across the KEPT (visible) region, used as the squelch
+    // reference. Excluding the leading historySize() lead-in keeps the fade
+    // dependent only on what's on screen — otherwise a strong burst just left
+    // of the visible edge would raise the floor and shift the fade as you pan.
+    const int lead = std::min<int>(count, static_cast<int>(historySize()));
     float peakLevel = 0.0f;
-    for (int i = 0; i < count; ++i) {
+    for (int i = lead; i < count; ++i) {
         if (level[i] > peakLevel)
             peakLevel = level[i];
+    }
+    if (peakLevel == 0.0f) {
+        // Window shorter than the lead-in (or an all-zero kept region): fall
+        // back to the full span so there's still a reference.
+        for (int i = 0; i < count; ++i)
+            if (level[i] > peakLevel)
+                peakLevel = level[i];
     }
     const float squelchFloor = peakLevel * kSquelchFrac;
 

--- a/src/fskdemod.cpp
+++ b/src/fskdemod.cpp
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (C) 2026
+ *
+ *  This file is part of inspectrum.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ */
+
+#include "fskdemod.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace {
+constexpr int kCenterWindow = 1024;
+constexpr int kLevelWindow = 256;
+
+static void movingAverage(const std::vector<float> &in, std::vector<float> &out, int window)
+{
+    if (in.empty())
+        return;
+
+    double sum = 0.0;
+    for (size_t i = 0; i < in.size(); ++i) {
+        const float v = std::isfinite(in[i]) ? in[i] : 0.0f;
+        sum += v;
+        if (i >= static_cast<size_t>(window))
+            sum -= std::isfinite(in[i - window]) ? in[i - window] : 0.0f;
+        const int n = std::min<int>(static_cast<int>(i) + 1, window);
+        out[i] = static_cast<float>(sum / n);
+    }
+}
+}
+
+FskDemod::FskDemod(std::shared_ptr<SampleSource<std::complex<float>>> src)
+    : SampleBuffer(std::make_shared<FrequencyDemod>(src))
+{
+}
+
+size_t FskDemod::historySize()
+{
+    return kCenterWindow;
+}
+
+void FskDemod::work(void *input, void *output, int count, size_t sampleid)
+{
+    (void)sampleid;
+
+    auto in = static_cast<float*>(input);
+    auto out = static_cast<float*>(output);
+
+    if (count <= 0)
+        return;
+
+    std::vector<float> centre(count, 0.0f);
+    std::vector<float> centered(count, 0.0f);
+    std::vector<float> absCentered(count, 0.0f);
+    std::vector<float> level(count, 0.0f);
+
+    movingAverage(std::vector<float>(in, in + count), centre, kCenterWindow);
+
+    for (int i = 0; i < count; ++i) {
+        const float v = std::isfinite(in[i]) ? in[i] : centre[i];
+        centered[i] = v - centre[i];
+        absCentered[i] = std::fabs(centered[i]);
+    }
+    movingAverage(absCentered, level, kLevelWindow);
+
+    for (int i = 0; i < count; ++i) {
+        const float scale = std::max(level[i] * 2.0f, 1e-5f);
+        float v = centered[i] / scale;
+        if (!std::isfinite(v))
+            v = 0.0f;
+        out[i] = std::max(-1.0f, std::min(1.0f, v));
+    }
+}
+
+void FskDemod::setCheapDemod(bool enabled)
+{
+    if (auto fm = std::dynamic_pointer_cast<FrequencyDemod>(src))
+        fm->setCheapDemod(enabled);
+}
+
+void FskDemod::setPostLpfCutoff(double hz)
+{
+    if (auto fm = std::dynamic_pointer_cast<FrequencyDemod>(src))
+        fm->setPostLpfCutoff(hz);
+}
+
+void FskDemod::setPostLpfMethod(FrequencyDemod::LpfMethod method)
+{
+    if (auto fm = std::dynamic_pointer_cast<FrequencyDemod>(src))
+        fm->setPostLpfMethod(method);
+}
+
+void FskDemod::setPostDecimation(int n)
+{
+    if (auto fm = std::dynamic_pointer_cast<FrequencyDemod>(src))
+        fm->setPostDecimation(n);
+}
+
+void FskDemod::setPredemodDecimation(int m)
+{
+    if (auto fm = std::dynamic_pointer_cast<FrequencyDemod>(src))
+        fm->setPredemodDecimation(m);
+}

--- a/src/fskdemod.cpp
+++ b/src/fskdemod.cpp
@@ -18,6 +18,11 @@
 namespace {
 constexpr int kCenterWindow = 1024;
 constexpr int kLevelWindow = 256;
+// Relative squelch: regions whose local deviation falls below this fraction of
+// the window's peak deviation are treated as gaps between bursts and faded, so
+// the AGC doesn't amplify their noise to full scale. Assumption-free (no
+// absolute-Hz threshold) and only bites when there's clear dynamic range.
+constexpr float kSquelchFrac = 0.08f;
 
 static void movingAverage(const std::vector<float> &in, std::vector<float> &out, int window)
 {
@@ -43,7 +48,13 @@ FskDemod::FskDemod(std::shared_ptr<SampleSource<std::complex<float>>> src)
 
 size_t FskDemod::historySize()
 {
-    return kCenterWindow;
+    // Warm BOTH cascaded moving averages. The level MA (kLevelWindow) reads
+    // absCentered values that each depend on a fully-ramped centre MA
+    // (kCenterWindow), so the first kept sample is only fully warmed after
+    // kCenterWindow + kLevelWindow lead-in samples. Discarding that much makes
+    // the output independent of where the render window's left edge falls
+    // (otherwise the leftmost ~kLevelWindow samples shift with the view).
+    return kCenterWindow + kLevelWindow;
 }
 
 void FskDemod::work(void *input, void *output, int count, size_t sampleid)
@@ -70,12 +81,29 @@ void FskDemod::work(void *input, void *output, int count, size_t sampleid)
     }
     movingAverage(absCentered, level, kLevelWindow);
 
+    // Peak deviation across the window, used as the squelch reference below.
+    float peakLevel = 0.0f;
+    for (int i = 0; i < count; ++i) {
+        if (level[i] > peakLevel)
+            peakLevel = level[i];
+    }
+    const float squelchFloor = peakLevel * kSquelchFrac;
+
     for (int i = 0; i < count; ++i) {
         const float scale = std::max(level[i] * 2.0f, 1e-5f);
         float v = centered[i] / scale;
         if (!std::isfinite(v))
             v = 0.0f;
-        out[i] = std::max(-1.0f, std::min(1.0f, v));
+        v = std::max(-1.0f, std::min(1.0f, v));
+        // Relative squelch: the AGC normalises every region to full scale, so a
+        // quiet gap between bursts would otherwise read as full-scale noise.
+        // Fade regions whose deviation is far below the window peak (smooth t²
+        // ramp so a weak-but-real burst isn't hard-cut).
+        if (squelchFloor > 0.0f && level[i] < squelchFloor) {
+            const float t = level[i] / squelchFloor;
+            v *= t * t;
+        }
+        out[i] = v;
     }
 }
 

--- a/src/fskdemod.h
+++ b/src/fskdemod.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2026
+ *
+ *  This file is part of inspectrum.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ */
+
+#pragma once
+
+#include "frequencydemod.h"
+#include "samplebuffer.h"
+
+class FskDemod : public SampleBuffer<float, float>
+{
+public:
+    FskDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
+    size_t historySize() override;
+    void work(void *input, void *output, int count, size_t sampleid) override;
+
+    void setCheapDemod(bool enabled);
+    void setPostLpfCutoff(double hz);
+    void setPostLpfMethod(FrequencyDemod::LpfMethod method);
+    void setPostDecimation(int n);
+    void setPredemodDecimation(int m);
+};

--- a/src/fskdemod.h
+++ b/src/fskdemod.h
@@ -20,6 +20,10 @@ public:
     FskDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
     size_t historySize() override;
     void work(void *input, void *output, int count, size_t sampleid) override;
+    // work() is a pure function of its input buffer (moving averages over
+    // locals, no member state — setters forward to the wrapped FrequencyDemod),
+    // so run it lock-free for concurrent tile rendering.
+    bool workIsReentrant() override { return true; }
 
     void setCheapDemod(bool enabled);
     void setPostLpfCutoff(double hz);

--- a/src/fskpolarplot.cpp
+++ b/src/fskpolarplot.cpp
@@ -195,22 +195,53 @@ void FskPolarPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> samp
     if (selectionEnabled && selectedRange.maximum > selectedRange.minimum)
         sampleRange = selectedRange;
 
-    if (!iqSource || sampleRange.maximum <= sampleRange.minimum)
-        return;
-
     const size_t delay = delayForRate();
-    if (delay == 0) {
-        // Either no symbol rate, or a symbol period too long for the window —
-        // both draw a hint rather than a meaningless ring.
+
+    // Always-visible status line just below the title, on a dark pill so it
+    // reads over the constellation — lets the symbol rate / delay be verified
+    // at a glance (a too-small delay collapses the scope to one blob).
+    auto drawStatus = [&](const QString &text) {
         painter.save();
-        painter.setPen(QColor(200, 200, 200));
-        const QString msg = (symbolRateHz > 0.0)
-            ? QStringLiteral("symbol period too long for the window\n(decimate, or raise the symbol rate)")
-            : QStringLiteral("set Symbol rate (Bd)\nto view the constellation");
-        painter.drawText(rect, Qt::AlignCenter, msg);
+        const QFontMetrics fmx(painter.font());
+        const int pad = 3;
+        const int x = rect.left() + 6;
+        const int baseline = rect.top() + 6 + fmx.height() + fmx.ascent();
+        painter.fillRect(x - pad, baseline - fmx.ascent() - pad,
+                         fmx.width(text) + 2 * pad, fmx.height() + 2 * pad,
+                         QColor(0, 0, 0, 180));
+        painter.setPen(QColor(230, 230, 230));
+        painter.drawText(x, baseline, text);
+        painter.restore();
+    };
+
+    if (!iqSource || sampleRange.maximum <= sampleRange.minimum) {
+        drawStatus(QStringLiteral("no data"));
+        return;
+    }
+
+    if (delay == 0) {
+        drawStatus(symbolRateHz > 0.0
+            ? QStringLiteral("symbol rate %1 Bd — period too long for window")
+                  .arg(symbolRateHz, 0, 'f', 0)
+            : QStringLiteral("symbol rate: not set"));
+        painter.save();
+        painter.setPen(QColor(160, 160, 160));
+        painter.drawText(rect, Qt::AlignCenter,
+            symbolRateHz > 0.0
+                ? QStringLiteral("symbol period too long\n(decimate or raise the rate)")
+                : QStringLiteral("set Symbol rate (Bd)\nto view the constellation"));
         painter.restore();
         return;
     }
+
+    // delay = round(Fs/baud); show it (and the baud) so a wrong setting — e.g. a
+    // too-small delay that collapses the scope to one blob — is obvious.
+    const QString scope = selectionEnabled ? QStringLiteral("sel") : QStringLiteral("view");
+    drawStatus(QStringLiteral("%1 · %2 Bd · delay %3 samp · gate %4%")
+                   .arg(scope)
+                   .arg(symbolRateHz, 0, 'f', symbolRateHz < 1000.0 ? 1 : 0)
+                   .arg(delay)
+                   .arg(levelGatePct));
 
     size_t len = sampleRange.maximum - sampleRange.minimum;
     if (len <= delay + 1)
@@ -236,19 +267,6 @@ void FskPolarPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> samp
     const bool needRender = !hasImage_ || imageKey_ != key;
     if (needRender && !running_)
         startRender(key);
-
-    // Cheap GUI-thread overlay: confirm the delay really is ~1 symbol.
-    painter.save();
-    painter.setPen(QColor(210, 210, 210));
-    const QString scope = selectionEnabled ? QStringLiteral("selection")
-                                           : QStringLiteral("visible");
-    const QString info = QStringLiteral("%1 · delay %2 samp = 1 symbol @ %3 Bd · gate %4%")
-                             .arg(scope)
-                             .arg(delay)
-                             .arg(symbolRateHz, 0, 'f', symbolRateHz < 1000.0 ? 1 : 0)
-                             .arg(levelGatePct);
-    painter.drawText(rect.left() + 6, rect.bottom() - 6, info);
-    painter.restore();
 }
 
 void FskPolarPlot::startRender(const RenderKey &k)

--- a/src/fskpolarplot.cpp
+++ b/src/fskpolarplot.cpp
@@ -11,24 +11,94 @@
 
 #include "fskpolarplot.h"
 
-#include <QFontMetrics>
+#include <QtConcurrent>
 #include <algorithm>
 #include <cmath>
+#include <vector>
 
 namespace {
-constexpr size_t kMaxSamples = 250000;
-constexpr size_t kMaxPoints = 60000;
+// Cap the contiguous IQ window we pull per render. At 15.36 Msps this is ~33 ms
+// (~600 TETRA symbols) — plenty of points for a dense constellation without an
+// unbounded getSamples through the tuner FIR.
+constexpr size_t kMaxSamples = 500000;
+// Cap the differential-product loop so very wide windows stay fast.
+constexpr size_t kMaxPoints = 400000;
 constexpr double kMinMag = 1e-8;
+
+static double radiusFor(int w, int h)
+{
+    const int side = std::max(10, std::min(w, h) - 16);
+    return side * 0.47;
 }
+
+// Worker-thread render: pull IQ, accumulate differential-phase hits into a
+// per-pixel counter, then map counts → a dark-green→white-hot heatmap. Runs
+// off the GUI thread; touches only the (kept-alive) source and local buffers.
+static QImage renderConstellation(std::shared_ptr<SampleSource<std::complex<float>>> src,
+                                  FskPolarPlot::RenderKey k)
+{
+    QImage img(k.w, k.h, QImage::Format_ARGB32);
+    img.fill(Qt::transparent);
+    if (!src || k.w < 1 || k.h < 1 || k.len <= k.delay + 1)
+        return img;
+
+    auto samples = src->getSamples(k.start, k.len);
+    if (!samples)
+        return img;
+
+    const double radius = radiusFor(k.w, k.h);
+    const double cx = k.w / 2.0;
+    const double cy = k.h / 2.0;
+
+    std::vector<uint32_t> hits(static_cast<size_t>(k.w) * k.h, 0);
+    uint32_t maxHit = 0;
+    const size_t usable = k.len - k.delay;
+    const size_t step = std::max<size_t>(1, usable / kMaxPoints);
+    for (size_t i = k.delay; i < k.len; i += step) {
+        const auto d = samples[i] * std::conj(samples[i - k.delay]);
+        const double mag = std::abs(d);
+        if (!std::isfinite(mag) || mag < kMinMag)
+            continue;
+        const double x = d.real() / mag;
+        const double y = d.imag() / mag;
+        const int px = static_cast<int>(std::lround(cx + x * radius));
+        const int py = static_cast<int>(std::lround(cy - y * radius));
+        if (px < 0 || px >= k.w || py < 0 || py >= k.h)
+            continue;
+        const uint32_t c = ++hits[static_cast<size_t>(py) * k.w + px];
+        if (c > maxHit)
+            maxHit = c;
+    }
+    if (maxHit == 0)
+        return img;
+
+    // Log scaling so a few hot symbol centres don't wash out the rest.
+    const double lmax = std::log1p(static_cast<double>(maxHit));
+    for (int y = 0; y < k.h; ++y) {
+        QRgb *line = reinterpret_cast<QRgb*>(img.scanLine(y));
+        for (int x = 0; x < k.w; ++x) {
+            const uint32_t c = hits[static_cast<size_t>(y) * k.w + x];
+            if (!c)
+                continue;
+            const double t = std::log1p(static_cast<double>(c)) / lmax; // 0..1
+            const int r = static_cast<int>(255.0 * std::pow(t, 1.6));
+            const int g = static_cast<int>(70.0 + 185.0 * t);
+            const int b = static_cast<int>(255.0 * std::pow(t, 2.4));
+            line[x] = qRgba(r, g, b, 255);
+        }
+    }
+    return img;
+}
+} // namespace
 
 FskPolarPlot::FskPolarPlot(std::shared_ptr<SampleSource<std::complex<float>>> source)
     : Plot(source), iqSource(std::move(source))
 {
 }
 
-void FskPolarPlot::setReferenceCutoff(double hz)
+void FskPolarPlot::setSymbolRate(double baud)
 {
-    referenceCutoffHz = hz;
+    symbolRateHz = baud > 0.0 ? baud : 0.0;
     emit repaint();
 }
 
@@ -39,19 +109,14 @@ void FskPolarPlot::setSelection(bool enabled, range_t<size_t> sampleRange)
     emit repaint();
 }
 
-size_t FskPolarPlot::delayFor(const QRect &rect, range_t<size_t> sampleRange) const
+size_t FskPolarPlot::delayForRate() const
 {
     const double rate = iqSource ? iqSource->rate() : 0.0;
-    if (referenceCutoffHz > 0.0 && rate > 0.0) {
-        const double d = rate / (4.0 * referenceCutoffHz);
+    if (symbolRateHz > 0.0 && rate > 0.0) {
+        const double d = rate / symbolRateHz; // samples per symbol
         return std::max<size_t>(1, std::min<size_t>(8192, static_cast<size_t>(d + 0.5)));
     }
-
-    const size_t span = sampleRange.maximum > sampleRange.minimum
-        ? sampleRange.maximum - sampleRange.minimum
-        : 1;
-    const int w = std::max(1, rect.width());
-    return std::max<size_t>(1, std::min<size_t>(8192, span / static_cast<size_t>(w * 4)));
+    return 0; // no symbol rate → caller draws a hint instead of a smear
 }
 
 void FskPolarPlot::paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
@@ -61,9 +126,8 @@ void FskPolarPlot::paintBack(QPainter &painter, QRect &rect, range_t<size_t> sam
     painter.save();
     painter.fillRect(rect, Qt::black);
 
-    const int side = std::max(10, std::min(rect.width(), rect.height()) - 16);
     const QPoint c(rect.left() + rect.width() / 2, rect.top() + rect.height() / 2);
-    const int r = side / 2;
+    const int r = static_cast<int>(radiusFor(rect.width(), rect.height()));
 
     painter.setRenderHint(QPainter::Antialiasing, true);
     painter.setPen(QPen(QColor(80, 80, 80), 1));
@@ -71,9 +135,19 @@ void FskPolarPlot::paintBack(QPainter &painter, QRect &rect, range_t<size_t> sam
     painter.drawLine(c.x() - r, c.y(), c.x() + r, c.y());
     painter.drawLine(c.x(), c.y() - r, c.x(), c.y() + r);
 
+    // Faint 45° orientation ticks — modulation-agnostic, but π/4-DQPSK clusters
+    // land on the four diagonals so they double as a read-off guide.
+    painter.setPen(QPen(QColor(60, 60, 60), 1));
+    for (int k = 0; k < 8; ++k) {
+        const double a = k * M_PI / 4.0;
+        const double inner = r * 0.88;
+        painter.drawLine(QPointF(c.x() + inner * std::cos(a), c.y() - inner * std::sin(a)),
+                         QPointF(c.x() + r * std::cos(a), c.y() - r * std::sin(a)));
+    }
+
     painter.setPen(QColor(180, 180, 180));
-    const QString title = QStringLiteral("FSK differential phase");
-    painter.drawText(rect.left() + 6, rect.top() + painter.fontMetrics().ascent() + 4, title);
+    painter.drawText(rect.left() + 6, rect.top() + painter.fontMetrics().ascent() + 4,
+                     QStringLiteral("FSK/PSK differential phase"));
     painter.restore();
 }
 
@@ -85,47 +159,81 @@ void FskPolarPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> samp
     if (!iqSource || sampleRange.maximum <= sampleRange.minimum)
         return;
 
-    const size_t delay = delayFor(rect, sampleRange);
+    const size_t delay = delayForRate();
+    if (delay == 0) {
+        // No symbol rate set: a wrong delay would draw a meaningless ring, so
+        // prompt instead. (This replaces the old zoom-dependent fallback.)
+        painter.save();
+        painter.setPen(QColor(200, 200, 200));
+        painter.drawText(rect, Qt::AlignCenter,
+                         QStringLiteral("set Symbol rate (Bd)\nto view the constellation"));
+        painter.restore();
+        return;
+    }
+
     size_t len = sampleRange.maximum - sampleRange.minimum;
     if (len <= delay + 1)
         return;
-
     size_t start = sampleRange.minimum;
     if (len > kMaxSamples) {
-        start += (len - kMaxSamples) / 2;
+        start += (len - kMaxSamples) / 2; // centre window of a long selection
         len = kMaxSamples;
     }
 
-    auto samples = iqSource->getSamples(start, len);
-    if (!samples)
+    const int w = rect.width();
+    const int h = rect.height();
+    if (w < 1 || h < 1)
         return;
 
-    const int side = std::max(10, std::min(rect.width(), rect.height()) - 16);
-    const QPoint c(rect.left() + rect.width() / 2, rect.top() + rect.height() / 2);
-    const double radius = side * 0.47;
-    const size_t usable = len > delay ? len - delay : 0;
-    const size_t step = std::max<size_t>(1, usable / kMaxPoints);
+    const RenderKey key{start, len, delay, w, h};
+    pendingKey_ = key;
+    havePending_ = true;
 
+    if (hasImage_ && imageKey_ == key)
+        painter.drawImage(rect.topLeft(), image_);
+
+    const bool needRender = !hasImage_ || imageKey_ != key;
+    if (needRender && !running_)
+        startRender(key);
+
+    // Cheap GUI-thread overlay: confirm the delay really is ~1 symbol.
     painter.save();
-    painter.setRenderHint(QPainter::Antialiasing, false);
-    painter.setPen(QColor(40, 230, 80, 90));
-
-    for (size_t i = delay; i < len; i += step) {
-        const auto d = samples[i] * std::conj(samples[i - delay]);
-        const double mag = std::abs(d);
-        if (!std::isfinite(mag) || mag < kMinMag)
-            continue;
-        const double x = d.real() / mag;
-        const double y = d.imag() / mag;
-        const int px = c.x() + static_cast<int>(x * radius);
-        const int py = c.y() - static_cast<int>(y * radius);
-        painter.drawPoint(px, py);
-    }
-
     painter.setPen(QColor(210, 210, 210));
-    const QString info = selectionEnabled
-        ? QStringLiteral("selection, delay %1 samples").arg(delay)
-        : QStringLiteral("visible range, delay %1 samples").arg(delay);
+    const QString scope = selectionEnabled ? QStringLiteral("selection")
+                                           : QStringLiteral("visible");
+    const QString info = QStringLiteral("%1 · delay %2 samp = 1 symbol @ %3 Bd")
+                             .arg(scope)
+                             .arg(delay)
+                             .arg(symbolRateHz, 0, 'f', symbolRateHz < 1000.0 ? 1 : 0);
     painter.drawText(rect.left() + 6, rect.bottom() - 6, info);
     painter.restore();
+}
+
+void FskPolarPlot::startRender(const RenderKey &k)
+{
+    if (!watcher_) {
+        watcher_ = new QFutureWatcher<QImage>(this);
+        // `this` as context: the lambda won't fire if the plot is destroyed.
+        connect(watcher_, &QFutureWatcher<QImage>::finished, this,
+                [this]() { onRenderReady(); });
+    }
+    running_ = true;
+    runningKey_ = k;
+    // Capture the source shared_ptr by value so the data outlives the plot if
+    // it's removed mid-render; the result is simply discarded in that case.
+    auto src = iqSource;
+    watcher_->setFuture(QtConcurrent::run(
+        [src, k]() { return renderConstellation(src, k); }));
+}
+
+void FskPolarPlot::onRenderReady()
+{
+    image_ = watcher_->result();
+    imageKey_ = runningKey_;
+    hasImage_ = true;
+    running_ = false;
+    // View moved on while rendering → chase the latest key.
+    if (havePending_ && pendingKey_ != imageKey_)
+        startRender(pendingKey_);
+    emit repaint();
 }

--- a/src/fskpolarplot.cpp
+++ b/src/fskpolarplot.cpp
@@ -21,8 +21,6 @@ namespace {
 // (~600 TETRA symbols) — plenty of points for a dense constellation without an
 // unbounded getSamples through the tuner FIR.
 constexpr size_t kMaxSamples = 500000;
-// Cap the differential-product loop so very wide windows stay fast.
-constexpr size_t kMaxPoints = 400000;
 constexpr double kMinMag = 1e-8;
 
 static double radiusFor(int w, int h)
@@ -52,9 +50,9 @@ static QImage renderConstellation(std::shared_ptr<SampleSource<std::complex<floa
 
     std::vector<uint32_t> hits(static_cast<size_t>(k.w) * k.h, 0);
     uint32_t maxHit = 0;
-    const size_t usable = k.len - k.delay;
-    const size_t step = std::max<size_t>(1, usable / kMaxPoints);
-    for (size_t i = k.delay; i < k.len; i += step) {
+    // k.len is capped at kMaxSamples, so visiting every sample is already a
+    // bounded (≤500k) loop — no decimation stride needed.
+    for (size_t i = k.delay; i < k.len; ++i) {
         const auto d = samples[i] * std::conj(samples[i - k.delay]);
         const double mag = std::abs(d);
         if (!std::isfinite(mag) || mag < kMinMag)
@@ -114,7 +112,15 @@ size_t FskPolarPlot::delayForRate() const
     const double rate = iqSource ? iqSource->rate() : 0.0;
     if (symbolRateHz > 0.0 && rate > 0.0) {
         const double d = rate / symbolRateHz; // samples per symbol
-        return std::max<size_t>(1, std::min<size_t>(8192, static_cast<size_t>(d + 0.5)));
+        const size_t want = static_cast<size_t>(d + 0.5);
+        // The differential needs both s[i] and s[i-delay] inside the render
+        // window. If one symbol exceeds the window the constellation can't be
+        // formed — return 0 so the caller hints, rather than silently clamping
+        // to a wrong delay that would still draw a (meaningless) ring while the
+        // overlay claimed it was one symbol.
+        if (want < 1 || want + 1 >= kMaxSamples)
+            return 0;
+        return want; // exact round(Fs/baud) — the overlay's "1 symbol" holds
     }
     return 0; // no symbol rate → caller draws a hint instead of a smear
 }
@@ -161,12 +167,14 @@ void FskPolarPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> samp
 
     const size_t delay = delayForRate();
     if (delay == 0) {
-        // No symbol rate set: a wrong delay would draw a meaningless ring, so
-        // prompt instead. (This replaces the old zoom-dependent fallback.)
+        // Either no symbol rate, or a symbol period too long for the window —
+        // both draw a hint rather than a meaningless ring.
         painter.save();
         painter.setPen(QColor(200, 200, 200));
-        painter.drawText(rect, Qt::AlignCenter,
-                         QStringLiteral("set Symbol rate (Bd)\nto view the constellation"));
+        const QString msg = (symbolRateHz > 0.0)
+            ? QStringLiteral("symbol period too long for the window\n(decimate, or raise the symbol rate)")
+            : QStringLiteral("set Symbol rate (Bd)\nto view the constellation");
+        painter.drawText(rect, Qt::AlignCenter, msg);
         painter.restore();
         return;
     }

--- a/src/fskpolarplot.cpp
+++ b/src/fskpolarplot.cpp
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (C) 2026
+ *
+ *  This file is part of inspectrum.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ */
+
+#include "fskpolarplot.h"
+
+#include <QFontMetrics>
+#include <algorithm>
+#include <cmath>
+
+namespace {
+constexpr size_t kMaxSamples = 250000;
+constexpr size_t kMaxPoints = 60000;
+constexpr double kMinMag = 1e-8;
+}
+
+FskPolarPlot::FskPolarPlot(std::shared_ptr<SampleSource<std::complex<float>>> source)
+    : Plot(source), iqSource(std::move(source))
+{
+}
+
+void FskPolarPlot::setReferenceCutoff(double hz)
+{
+    referenceCutoffHz = hz;
+    emit repaint();
+}
+
+void FskPolarPlot::setSelection(bool enabled, range_t<size_t> sampleRange)
+{
+    selectionEnabled = enabled;
+    selectedRange = sampleRange;
+    emit repaint();
+}
+
+size_t FskPolarPlot::delayFor(const QRect &rect, range_t<size_t> sampleRange) const
+{
+    const double rate = iqSource ? iqSource->rate() : 0.0;
+    if (referenceCutoffHz > 0.0 && rate > 0.0) {
+        const double d = rate / (4.0 * referenceCutoffHz);
+        return std::max<size_t>(1, std::min<size_t>(8192, static_cast<size_t>(d + 0.5)));
+    }
+
+    const size_t span = sampleRange.maximum > sampleRange.minimum
+        ? sampleRange.maximum - sampleRange.minimum
+        : 1;
+    const int w = std::max(1, rect.width());
+    return std::max<size_t>(1, std::min<size_t>(8192, span / static_cast<size_t>(w * 4)));
+}
+
+void FskPolarPlot::paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
+{
+    Q_UNUSED(sampleRange);
+
+    painter.save();
+    painter.fillRect(rect, Qt::black);
+
+    const int side = std::max(10, std::min(rect.width(), rect.height()) - 16);
+    const QPoint c(rect.left() + rect.width() / 2, rect.top() + rect.height() / 2);
+    const int r = side / 2;
+
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(QPen(QColor(80, 80, 80), 1));
+    painter.drawEllipse(c, r, r);
+    painter.drawLine(c.x() - r, c.y(), c.x() + r, c.y());
+    painter.drawLine(c.x(), c.y() - r, c.x(), c.y() + r);
+
+    painter.setPen(QColor(180, 180, 180));
+    const QString title = QStringLiteral("FSK differential phase");
+    painter.drawText(rect.left() + 6, rect.top() + painter.fontMetrics().ascent() + 4, title);
+    painter.restore();
+}
+
+void FskPolarPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
+{
+    if (selectionEnabled && selectedRange.maximum > selectedRange.minimum)
+        sampleRange = selectedRange;
+
+    if (!iqSource || sampleRange.maximum <= sampleRange.minimum)
+        return;
+
+    const size_t delay = delayFor(rect, sampleRange);
+    size_t len = sampleRange.maximum - sampleRange.minimum;
+    if (len <= delay + 1)
+        return;
+
+    size_t start = sampleRange.minimum;
+    if (len > kMaxSamples) {
+        start += (len - kMaxSamples) / 2;
+        len = kMaxSamples;
+    }
+
+    auto samples = iqSource->getSamples(start, len);
+    if (!samples)
+        return;
+
+    const int side = std::max(10, std::min(rect.width(), rect.height()) - 16);
+    const QPoint c(rect.left() + rect.width() / 2, rect.top() + rect.height() / 2);
+    const double radius = side * 0.47;
+    const size_t usable = len > delay ? len - delay : 0;
+    const size_t step = std::max<size_t>(1, usable / kMaxPoints);
+
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, false);
+    painter.setPen(QColor(40, 230, 80, 90));
+
+    for (size_t i = delay; i < len; i += step) {
+        const auto d = samples[i] * std::conj(samples[i - delay]);
+        const double mag = std::abs(d);
+        if (!std::isfinite(mag) || mag < kMinMag)
+            continue;
+        const double x = d.real() / mag;
+        const double y = d.imag() / mag;
+        const int px = c.x() + static_cast<int>(x * radius);
+        const int py = c.y() - static_cast<int>(y * radius);
+        painter.drawPoint(px, py);
+    }
+
+    painter.setPen(QColor(210, 210, 210));
+    const QString info = selectionEnabled
+        ? QStringLiteral("selection, delay %1 samples").arg(delay)
+        : QStringLiteral("visible range, delay %1 samples").arg(delay);
+    painter.drawText(rect.left() + 6, rect.bottom() - 6, info);
+    painter.restore();
+}

--- a/src/fskpolarplot.cpp
+++ b/src/fskpolarplot.cpp
@@ -125,6 +125,14 @@ void FskPolarPlot::setLevelGate(int pct)
     emit repaint();
 }
 
+void FskPolarPlot::invalidateEvent()
+{
+    // Bump the epoch so the next paint's RenderKey differs from the cached
+    // image and forces a re-render against the new upstream data.
+    ++dataEpoch_;
+    emit repaint();
+}
+
 void FskPolarPlot::setSelection(bool enabled, range_t<size_t> sampleRange)
 {
     selectionEnabled = enabled;
@@ -218,7 +226,7 @@ void FskPolarPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> samp
     if (w < 1 || h < 1)
         return;
 
-    const RenderKey key{start, len, delay, w, h, levelGatePct};
+    const RenderKey key{start, len, delay, w, h, levelGatePct, dataEpoch_};
     pendingKey_ = key;
     havePending_ = true;
 

--- a/src/fskpolarplot.cpp
+++ b/src/fskpolarplot.cpp
@@ -48,33 +48,77 @@ static QImage renderConstellation(std::shared_ptr<SampleSource<std::complex<floa
     const double cx = k.w / 2.0;
     const double cy = k.h / 2.0;
 
-    // Pass 1: window reference = peak differential magnitude |s[i]|·|s[i-delay]|.
-    // In-burst samples cluster near this; noise/gaps sit far below it.
+    // Build the differential points to plot.
+    std::vector<std::complex<float>> dv;
+    if (k.symbolTimed && k.sps >= 2.0) {
+        // Symbol-timed: resample to one sample per symbol at fractional spacing
+        // k.sps (linear interp), at the timing phase that maximises symbol
+        // energy, then take the 1-symbol differential. This collapses the
+        // inter-symbol trajectory "spokes" so only the decision-point clusters
+        // remain (e.g. the 4 points of π/4-DQPSK).
+        const size_t M = static_cast<size_t>(k.len / k.sps);
+        if (M < 4)
+            return img;
+        auto interp = [&](double pos) -> std::complex<float> {
+            if (pos < 0.0) pos = 0.0;
+            const size_t i0 = static_cast<size_t>(pos);
+            if (i0 + 1 >= k.len) return samples[k.len - 1];
+            const float f = static_cast<float>(pos - i0);
+            return samples[i0] * (1.0f - f) + samples[i0 + 1] * f;
+        };
+        // Timing recovery: pick the fractional phase maximising mean symbol
+        // energy (symbol centres are the energy peaks for pulse-shaped signals;
+        // for constant-envelope FSK any phase is equivalent, so it's a no-op).
+        double bestPhase = 0.0, bestScore = -1.0;
+        for (int p = 0; p < 16; ++p) {
+            const double ph = p / 16.0;
+            double e = 0.0; size_t cnt = 0;
+            for (size_t s = 0; s < M; s += 4) {
+                const double pos = (s + ph) * k.sps;
+                if (pos >= k.len) break;
+                e += std::norm(interp(pos)); ++cnt;
+            }
+            if (cnt && e / cnt > bestScore) { bestScore = e / cnt; bestPhase = ph; }
+        }
+        std::vector<std::complex<float>> sym;
+        sym.reserve(M);
+        for (size_t s = 0; s < M; ++s) {
+            const double pos = (s + bestPhase) * k.sps;
+            if (pos >= k.len) break;
+            sym.push_back(interp(pos));
+        }
+        dv.reserve(sym.size());
+        for (size_t s = 1; s < sym.size(); ++s)
+            dv.push_back(sym[s] * std::conj(sym[s - 1]));
+    } else {
+        // Full-rate: every sample's 1-symbol-delayed differential (the
+        // trajectory, including inter-symbol transitions). k.len is capped at
+        // kMaxSamples so this is a bounded (≤500k) loop.
+        dv.reserve(k.len - k.delay);
+        for (size_t i = k.delay; i < k.len; ++i)
+            dv.push_back(samples[i] * std::conj(samples[i - k.delay]));
+    }
+    if (dv.empty())
+        return img;
+
+    // Window reference = peak differential magnitude. In-burst points cluster
+    // near it; noise/gaps sit far below. Points are placed at radius |d|/refMag
+    // — NOT normalised to the unit circle — so weak residual points fall toward
+    // the centre instead of polluting the cluster ring.
     double refMag = 0.0;
-    for (size_t i = k.delay; i < k.len; ++i) {
-        const auto d = samples[i] * std::conj(samples[i - k.delay]);
+    for (const auto &d : dv) {
         const double m = std::abs(d);
         if (std::isfinite(m) && m > refMag)
             refMag = m;
     }
     if (refMag < kMinMag)
         return img;
-
-    // Signal-strength gate: drop samples below gatePct·peak so only strong
-    // (in-burst) parts reach the scope. Points are placed at radius |d|/refMag —
-    // NOT normalised to the unit circle — so weak residual points fall toward
-    // the centre instead of polluting the cluster ring, and symbol centres sit
-    // out near the rim. (The old per-point /mag normalisation is exactly what
-    // pulled noise up onto the circle.)
     const double gate = std::max(refMag * (k.gatePct / 100.0), kMinMag);
     const double rscale = radius / refMag;
 
     std::vector<uint32_t> hits(static_cast<size_t>(k.w) * k.h, 0);
     uint32_t maxHit = 0;
-    // k.len is capped at kMaxSamples, so visiting every sample is already a
-    // bounded (≤500k) loop — no decimation stride needed.
-    for (size_t i = k.delay; i < k.len; ++i) {
-        const auto d = samples[i] * std::conj(samples[i - k.delay]);
+    for (const auto &d : dv) {
         const double mag = std::abs(d);
         if (!std::isfinite(mag) || mag < gate)
             continue;
@@ -122,6 +166,12 @@ void FskPolarPlot::setSymbolRate(double baud)
 void FskPolarPlot::setLevelGate(int pct)
 {
     levelGatePct = std::max(0, std::min(100, pct));
+    emit repaint();
+}
+
+void FskPolarPlot::setSymbolTimed(bool on)
+{
+    symbolTimed_ = on;
     emit repaint();
 }
 
@@ -236,12 +286,15 @@ void FskPolarPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> samp
 
     // delay = round(Fs/baud); show it (and the baud) so a wrong setting — e.g. a
     // too-small delay that collapses the scope to one blob — is obvious.
+    const double sps = iqSource->rate() / symbolRateHz; // exact (fractional)
+    const bool symbolTimed = symbolTimed_ && sps >= 2.0;
     const QString scope = selectionEnabled ? QStringLiteral("sel") : QStringLiteral("view");
-    drawStatus(QStringLiteral("%1 · %2 Bd · delay %3 samp · gate %4%")
+    drawStatus(QStringLiteral("%1 · %2 Bd · delay %3 samp · gate %4%%5")
                    .arg(scope)
                    .arg(symbolRateHz, 0, 'f', symbolRateHz < 1000.0 ? 1 : 0)
                    .arg(delay)
-                   .arg(levelGatePct));
+                   .arg(levelGatePct)
+                   .arg(symbolTimed ? QStringLiteral(" · sym-timed") : QString()));
 
     size_t len = sampleRange.maximum - sampleRange.minimum;
     if (len <= delay + 1)
@@ -257,7 +310,7 @@ void FskPolarPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> samp
     if (w < 1 || h < 1)
         return;
 
-    const RenderKey key{start, len, delay, w, h, levelGatePct, dataEpoch_};
+    const RenderKey key{start, len, delay, w, h, levelGatePct, dataEpoch_, symbolTimed, sps};
     pendingKey_ = key;
     havePending_ = true;
 

--- a/src/fskpolarplot.cpp
+++ b/src/fskpolarplot.cpp
@@ -48,6 +48,27 @@ static QImage renderConstellation(std::shared_ptr<SampleSource<std::complex<floa
     const double cx = k.w / 2.0;
     const double cy = k.h / 2.0;
 
+    // Pass 1: window reference = peak differential magnitude |s[i]|·|s[i-delay]|.
+    // In-burst samples cluster near this; noise/gaps sit far below it.
+    double refMag = 0.0;
+    for (size_t i = k.delay; i < k.len; ++i) {
+        const auto d = samples[i] * std::conj(samples[i - k.delay]);
+        const double m = std::abs(d);
+        if (std::isfinite(m) && m > refMag)
+            refMag = m;
+    }
+    if (refMag < kMinMag)
+        return img;
+
+    // Signal-strength gate: drop samples below gatePct·peak so only strong
+    // (in-burst) parts reach the scope. Points are placed at radius |d|/refMag —
+    // NOT normalised to the unit circle — so weak residual points fall toward
+    // the centre instead of polluting the cluster ring, and symbol centres sit
+    // out near the rim. (The old per-point /mag normalisation is exactly what
+    // pulled noise up onto the circle.)
+    const double gate = std::max(refMag * (k.gatePct / 100.0), kMinMag);
+    const double rscale = radius / refMag;
+
     std::vector<uint32_t> hits(static_cast<size_t>(k.w) * k.h, 0);
     uint32_t maxHit = 0;
     // k.len is capped at kMaxSamples, so visiting every sample is already a
@@ -55,12 +76,10 @@ static QImage renderConstellation(std::shared_ptr<SampleSource<std::complex<floa
     for (size_t i = k.delay; i < k.len; ++i) {
         const auto d = samples[i] * std::conj(samples[i - k.delay]);
         const double mag = std::abs(d);
-        if (!std::isfinite(mag) || mag < kMinMag)
+        if (!std::isfinite(mag) || mag < gate)
             continue;
-        const double x = d.real() / mag;
-        const double y = d.imag() / mag;
-        const int px = static_cast<int>(std::lround(cx + x * radius));
-        const int py = static_cast<int>(std::lround(cy - y * radius));
+        const int px = static_cast<int>(std::lround(cx + d.real() * rscale));
+        const int py = static_cast<int>(std::lround(cy - d.imag() * rscale));
         if (px < 0 || px >= k.w || py < 0 || py >= k.h)
             continue;
         const uint32_t c = ++hits[static_cast<size_t>(py) * k.w + px];
@@ -97,6 +116,12 @@ FskPolarPlot::FskPolarPlot(std::shared_ptr<SampleSource<std::complex<float>>> so
 void FskPolarPlot::setSymbolRate(double baud)
 {
     symbolRateHz = baud > 0.0 ? baud : 0.0;
+    emit repaint();
+}
+
+void FskPolarPlot::setLevelGate(int pct)
+{
+    levelGatePct = std::max(0, std::min(100, pct));
     emit repaint();
 }
 
@@ -193,7 +218,7 @@ void FskPolarPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> samp
     if (w < 1 || h < 1)
         return;
 
-    const RenderKey key{start, len, delay, w, h};
+    const RenderKey key{start, len, delay, w, h, levelGatePct};
     pendingKey_ = key;
     havePending_ = true;
 
@@ -209,10 +234,11 @@ void FskPolarPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> samp
     painter.setPen(QColor(210, 210, 210));
     const QString scope = selectionEnabled ? QStringLiteral("selection")
                                            : QStringLiteral("visible");
-    const QString info = QStringLiteral("%1 · delay %2 samp = 1 symbol @ %3 Bd")
+    const QString info = QStringLiteral("%1 · delay %2 samp = 1 symbol @ %3 Bd · gate %4%")
                              .arg(scope)
                              .arg(delay)
-                             .arg(symbolRateHz, 0, 'f', symbolRateHz < 1000.0 ? 1 : 0);
+                             .arg(symbolRateHz, 0, 'f', symbolRateHz < 1000.0 ? 1 : 0)
+                             .arg(levelGatePct);
     painter.drawText(rect.left() + 6, rect.bottom() - 6, info);
     painter.restore();
 }

--- a/src/fskpolarplot.h
+++ b/src/fskpolarplot.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2026
+ *
+ *  This file is part of inspectrum.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ */
+
+#pragma once
+
+#include "plot.h"
+#include "samplesource.h"
+
+#include <complex>
+#include <memory>
+
+class FskPolarPlot : public Plot
+{
+public:
+    FskPolarPlot(std::shared_ptr<SampleSource<std::complex<float>>> source);
+    void paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
+    void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
+    void setReferenceCutoff(double hz);
+    void setSelection(bool enabled, range_t<size_t> sampleRange);
+
+private:
+    std::shared_ptr<SampleSource<std::complex<float>>> iqSource;
+    double referenceCutoffHz = 0.0;
+    bool selectionEnabled = false;
+    range_t<size_t> selectedRange{0, 0};
+    size_t delayFor(const QRect &rect, range_t<size_t> sampleRange) const;
+};

--- a/src/fskpolarplot.h
+++ b/src/fskpolarplot.h
@@ -39,6 +39,11 @@ public:
     // magnitude (0..100). Samples below it are dropped so only strong (in-burst)
     // parts reach the scope. 0 disables the gate.
     void setLevelGate(int pct);
+    // When true, resample to one point per symbol (fractional spacing, timing
+    // recovered) and plot the 1-symbol differential — collapsing the
+    // inter-symbol trajectory "spokes" into clean decision-point clusters.
+    // When false, plot the full-rate differential (shows the trajectory).
+    void setSymbolTimed(bool on);
     void setSelection(bool enabled, range_t<size_t> sampleRange);
     // Upstream changed (tuner retune, file/param change): drop the cached image
     // and re-render. The render key only captures view geometry, so without
@@ -56,10 +61,13 @@ public:
         int h = 0;
         int gatePct = 0;
         unsigned epoch = 0;
+        bool symbolTimed = false;
+        double sps = 0.0; // exact samples/symbol (Fs/baud); fractional
         bool operator==(const RenderKey &o) const {
             return start == o.start && len == o.len && delay == o.delay &&
                    w == o.w && h == o.h && gatePct == o.gatePct &&
-                   epoch == o.epoch;
+                   epoch == o.epoch && symbolTimed == o.symbolTimed &&
+                   sps == o.sps;
         }
         bool operator!=(const RenderKey &o) const { return !(*this == o); }
     };
@@ -68,6 +76,7 @@ private:
     std::shared_ptr<SampleSource<std::complex<float>>> iqSource;
     double symbolRateHz = 0.0;
     int levelGatePct = 15;
+    bool symbolTimed_ = true;
     unsigned dataEpoch_ = 0;
     bool selectionEnabled = false;
     range_t<size_t> selectedRange{0, 0};

--- a/src/fskpolarplot.h
+++ b/src/fskpolarplot.h
@@ -40,6 +40,10 @@ public:
     // parts reach the scope. 0 disables the gate.
     void setLevelGate(int pct);
     void setSelection(bool enabled, range_t<size_t> sampleRange);
+    // Upstream changed (tuner retune, file/param change): drop the cached image
+    // and re-render. The render key only captures view geometry, so without
+    // this a retune at the same view/selection would re-blit a stale scope.
+    void invalidateEvent() override;
 
     // Everything that determines the rendered image. The worker re-runs only
     // when this changes, so hover/scroll that don't move the window are free.
@@ -51,9 +55,11 @@ public:
         int w = 0;
         int h = 0;
         int gatePct = 0;
+        unsigned epoch = 0;
         bool operator==(const RenderKey &o) const {
             return start == o.start && len == o.len && delay == o.delay &&
-                   w == o.w && h == o.h && gatePct == o.gatePct;
+                   w == o.w && h == o.h && gatePct == o.gatePct &&
+                   epoch == o.epoch;
         }
         bool operator!=(const RenderKey &o) const { return !(*this == o); }
     };
@@ -62,6 +68,7 @@ private:
     std::shared_ptr<SampleSource<std::complex<float>>> iqSource;
     double symbolRateHz = 0.0;
     int levelGatePct = 15;
+    unsigned dataEpoch_ = 0;
     bool selectionEnabled = false;
     range_t<size_t> selectedRange{0, 0};
 

--- a/src/fskpolarplot.h
+++ b/src/fskpolarplot.h
@@ -35,6 +35,10 @@ public:
     // 0 (unset) draws nothing but a hint — a wrong delay yields a meaningless
     // smear, so we decline to guess.
     void setSymbolRate(double baud);
+    // Signal-strength gate as a percentage of the window's peak differential
+    // magnitude (0..100). Samples below it are dropped so only strong (in-burst)
+    // parts reach the scope. 0 disables the gate.
+    void setLevelGate(int pct);
     void setSelection(bool enabled, range_t<size_t> sampleRange);
 
     // Everything that determines the rendered image. The worker re-runs only
@@ -46,9 +50,10 @@ public:
         size_t delay = 0;
         int w = 0;
         int h = 0;
+        int gatePct = 0;
         bool operator==(const RenderKey &o) const {
             return start == o.start && len == o.len && delay == o.delay &&
-                   w == o.w && h == o.h;
+                   w == o.w && h == o.h && gatePct == o.gatePct;
         }
         bool operator!=(const RenderKey &o) const { return !(*this == o); }
     };
@@ -56,6 +61,7 @@ public:
 private:
     std::shared_ptr<SampleSource<std::complex<float>>> iqSource;
     double symbolRateHz = 0.0;
+    int levelGatePct = 15;
     bool selectionEnabled = false;
     range_t<size_t> selectedRange{0, 0};
 

--- a/src/fskpolarplot.h
+++ b/src/fskpolarplot.h
@@ -14,22 +14,62 @@
 #include "plot.h"
 #include "samplesource.h"
 
+#include <QFutureWatcher>
+#include <QImage>
 #include <complex>
 #include <memory>
 
+// Differential-phase constellation: plots d = s[i]·conj(s[i-delay]) on the
+// unit circle, where `delay` is one symbol period (Fs / symbol rate). This is
+// the natural domain for differentially-encoded PSK (π/4-DQPSK clusters at
+// ±45°/±135°) and a useful cross-check for FSK. The scatter is accumulated as
+// a per-pixel density heatmap on a worker thread so symbol-centre phases
+// (revisited often) glow brighter than the inter-symbol transition smear.
 class FskPolarPlot : public Plot
 {
 public:
     FskPolarPlot(std::shared_ptr<SampleSource<std::complex<float>>> source);
     void paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
     void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
-    void setReferenceCutoff(double hz);
+    // Symbol rate in baud. Drives the differential delay (= round(Fs/baud)).
+    // 0 (unset) draws nothing but a hint — a wrong delay yields a meaningless
+    // smear, so we decline to guess.
+    void setSymbolRate(double baud);
     void setSelection(bool enabled, range_t<size_t> sampleRange);
+
+    // Everything that determines the rendered image. The worker re-runs only
+    // when this changes, so hover/scroll that don't move the window are free.
+    // Public so the file-scope worker render helper can take it by value.
+    struct RenderKey {
+        size_t start = 0;
+        size_t len = 0;
+        size_t delay = 0;
+        int w = 0;
+        int h = 0;
+        bool operator==(const RenderKey &o) const {
+            return start == o.start && len == o.len && delay == o.delay &&
+                   w == o.w && h == o.h;
+        }
+        bool operator!=(const RenderKey &o) const { return !(*this == o); }
+    };
 
 private:
     std::shared_ptr<SampleSource<std::complex<float>>> iqSource;
-    double referenceCutoffHz = 0.0;
+    double symbolRateHz = 0.0;
     bool selectionEnabled = false;
     range_t<size_t> selectedRange{0, 0};
-    size_t delayFor(const QRect &rect, range_t<size_t> sampleRange) const;
+
+    // Off-GUI-thread render pipeline (mirrors TracePlot's float path).
+    QFutureWatcher<QImage> *watcher_ = nullptr;
+    QImage image_;
+    RenderKey imageKey_;
+    RenderKey runningKey_;
+    RenderKey pendingKey_;
+    bool hasImage_ = false;
+    bool running_ = false;
+    bool havePending_ = false;
+
+    size_t delayForRate() const;
+    void startRender(const RenderKey &k);
+    void onRenderReady();
 };

--- a/src/histogramplot.cpp
+++ b/src/histogramplot.cpp
@@ -1,0 +1,192 @@
+/*
+ *  Copyright (C) 2026
+ *
+ *  This file is part of inspectrum.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ */
+
+#include "histogramplot.h"
+
+#include "util.h"
+
+#include <QtConcurrent>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace {
+// Cap the contiguous window pulled per render (the float source can fan out to
+// the batched FM demod). A histogram only needs a representative sample.
+constexpr size_t kMaxSamples = 1000000;
+
+static QString fmtValue(double v)
+{
+    return QString::fromStdString(formatSIValue(v));
+}
+
+static QImage renderHistogram(std::shared_ptr<SampleSource<float>> src,
+                              HistogramPlot::RenderKey k)
+{
+    QImage img(k.w, k.h, QImage::Format_ARGB32);
+    img.fill(Qt::transparent);
+    if (!src || k.w < 2 || k.h < 2 || k.len == 0)
+        return img;
+
+    auto samples = src->getSamples(k.start, k.len);
+    if (!samples)
+        return img;
+
+    // Auto-range over the finite samples.
+    double lo = std::numeric_limits<double>::infinity();
+    double hi = -std::numeric_limits<double>::infinity();
+    for (size_t i = 0; i < k.len; ++i) {
+        const double v = samples[i];
+        if (!std::isfinite(v))
+            continue;
+        lo = std::min(lo, v);
+        hi = std::max(hi, v);
+    }
+    if (!std::isfinite(lo) || !std::isfinite(hi) || hi <= lo)
+        return img;
+    const double pad = (hi - lo) * 0.05;
+    lo -= pad;
+    hi += pad;
+
+    const int nbins = std::min(256, std::max(32, k.w / 4));
+    std::vector<uint32_t> bins(nbins, 0);
+    uint32_t maxBin = 0;
+    const double span = hi - lo;
+    for (size_t i = 0; i < k.len; ++i) {
+        const double v = samples[i];
+        if (!std::isfinite(v))
+            continue;
+        int b = static_cast<int>((v - lo) / span * nbins);
+        if (b < 0) b = 0;
+        if (b >= nbins) b = nbins - 1;
+        const uint32_t c = ++bins[b];
+        if (c > maxBin)
+            maxBin = c;
+    }
+    if (maxBin == 0)
+        return img;
+
+    QPainter p(&img);
+    p.setRenderHint(QPainter::Antialiasing, false);
+
+    // Bars: value on X (lo→hi left→right), count as height. sqrt scaling lifts
+    // small lobes so a weak fourth FSK level still reads.
+    p.setPen(Qt::NoPen);
+    p.setBrush(QColor(40, 210, 90));
+    const int baseY = k.h - 1;
+    for (int b = 0; b < nbins; ++b) {
+        if (!bins[b])
+            continue;
+        const double frac = static_cast<double>(bins[b]) / maxBin;
+        const int barH = static_cast<int>(std::sqrt(frac) * (k.h - 14));
+        const int x0 = static_cast<int>(static_cast<double>(b) / nbins * k.w);
+        int x1 = static_cast<int>(static_cast<double>(b + 1) / nbins * k.w);
+        if (x1 <= x0)
+            x1 = x0 + 1;
+        p.drawRect(x0, baseY - barH, x1 - x0 - (x1 - x0 > 1 ? 1 : 0), barH);
+    }
+
+    // A zero reference line, if zero is in range (FSK levels straddle it).
+    if (lo < 0.0 && hi > 0.0) {
+        const int zx = static_cast<int>((0.0 - lo) / span * k.w);
+        p.setPen(QPen(QColor(200, 200, 200, 110), 1, Qt::DashLine));
+        p.drawLine(zx, 0, zx, k.h);
+    }
+
+    // Value-axis endpoints so the peaks have a scale.
+    p.setPen(QColor(210, 210, 210));
+    p.drawText(2, k.h - 3, fmtValue(lo));
+    const QString hiText = fmtValue(hi);
+    p.drawText(k.w - 2 - p.fontMetrics().width(hiText), k.h - 3, hiText);
+    return img;
+}
+} // namespace
+
+HistogramPlot::HistogramPlot(std::shared_ptr<SampleSource<float>> source)
+    : Plot(source), floatSource(std::move(source))
+{
+}
+
+void HistogramPlot::setSelection(bool enabled, range_t<size_t> sampleRange)
+{
+    selectionEnabled = enabled;
+    selectedRange = sampleRange;
+    emit repaint();
+}
+
+void HistogramPlot::paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
+{
+    Q_UNUSED(sampleRange);
+    painter.save();
+    painter.fillRect(rect, Qt::black);
+    painter.setPen(QColor(180, 180, 180));
+    painter.drawText(rect.left() + 6, rect.top() + painter.fontMetrics().ascent() + 4,
+                     QStringLiteral("value histogram"));
+    painter.restore();
+}
+
+void HistogramPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
+{
+    if (selectionEnabled && selectedRange.maximum > selectedRange.minimum)
+        sampleRange = selectedRange;
+
+    if (!floatSource || sampleRange.maximum <= sampleRange.minimum)
+        return;
+
+    size_t len = sampleRange.maximum - sampleRange.minimum;
+    size_t start = sampleRange.minimum;
+    if (len > kMaxSamples) {
+        start += (len - kMaxSamples) / 2;
+        len = kMaxSamples;
+    }
+
+    const int w = rect.width();
+    const int h = rect.height();
+    if (w < 1 || h < 1)
+        return;
+
+    const RenderKey key{start, len, w, h};
+    pendingKey_ = key;
+    havePending_ = true;
+
+    if (hasImage_ && imageKey_ == key)
+        painter.drawImage(rect.topLeft(), image_);
+
+    const bool needRender = !hasImage_ || imageKey_ != key;
+    if (needRender && !running_)
+        startRender(key);
+}
+
+void HistogramPlot::startRender(const RenderKey &k)
+{
+    if (!watcher_) {
+        watcher_ = new QFutureWatcher<QImage>(this);
+        connect(watcher_, &QFutureWatcher<QImage>::finished, this,
+                [this]() { onRenderReady(); });
+    }
+    running_ = true;
+    runningKey_ = k;
+    auto src = floatSource;
+    watcher_->setFuture(QtConcurrent::run(
+        [src, k]() { return renderHistogram(src, k); }));
+}
+
+void HistogramPlot::onRenderReady()
+{
+    image_ = watcher_->result();
+    imageKey_ = runningKey_;
+    hasImage_ = true;
+    running_ = false;
+    if (havePending_ && pendingKey_ != imageKey_)
+        startRender(pendingKey_);
+    emit repaint();
+}

--- a/src/histogramplot.cpp
+++ b/src/histogramplot.cpp
@@ -123,6 +123,12 @@ void HistogramPlot::setSelection(bool enabled, range_t<size_t> sampleRange)
     emit repaint();
 }
 
+void HistogramPlot::invalidateEvent()
+{
+    ++dataEpoch_;
+    emit repaint();
+}
+
 void HistogramPlot::paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     Q_UNUSED(sampleRange);
@@ -154,7 +160,7 @@ void HistogramPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sam
     if (w < 1 || h < 1)
         return;
 
-    const RenderKey key{start, len, w, h};
+    const RenderKey key{start, len, w, h, dataEpoch_};
     pendingKey_ = key;
     havePending_ = true;
 

--- a/src/histogramplot.h
+++ b/src/histogramplot.h
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (C) 2026
+ *
+ *  This file is part of inspectrum.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ */
+
+#pragma once
+
+#include "plot.h"
+#include "samplesource.h"
+
+#include <QFutureWatcher>
+#include <QImage>
+#include <memory>
+
+// Value histogram of a float derived source. The number of peaks reveals the
+// modulation order clock-free: 2-FSK shows two lobes, 4-FSK four, GFSK smears
+// them, a PSK/noise blob is unimodal. Built on a worker thread (the float
+// source can fan out to the batched FM-demod), keyed so idle repaints are free.
+class HistogramPlot : public Plot
+{
+public:
+    HistogramPlot(std::shared_ptr<SampleSource<float>> source);
+    void paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
+    void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
+    void setSelection(bool enabled, range_t<size_t> sampleRange);
+
+    // Public so the file-scope worker render helper can take it by value.
+    struct RenderKey {
+        size_t start = 0;
+        size_t len = 0;
+        int w = 0;
+        int h = 0;
+        bool operator==(const RenderKey &o) const {
+            return start == o.start && len == o.len && w == o.w && h == o.h;
+        }
+        bool operator!=(const RenderKey &o) const { return !(*this == o); }
+    };
+
+private:
+    std::shared_ptr<SampleSource<float>> floatSource;
+    bool selectionEnabled = false;
+    range_t<size_t> selectedRange{0, 0};
+
+    QFutureWatcher<QImage> *watcher_ = nullptr;
+    QImage image_;
+    RenderKey imageKey_;
+    RenderKey runningKey_;
+    RenderKey pendingKey_;
+    bool hasImage_ = false;
+    bool running_ = false;
+    bool havePending_ = false;
+
+    void startRender(const RenderKey &k);
+    void onRenderReady();
+};

--- a/src/histogramplot.h
+++ b/src/histogramplot.h
@@ -29,6 +29,10 @@ public:
     void paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
     void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
     void setSelection(bool enabled, range_t<size_t> sampleRange);
+    // Re-render on upstream change (tuner retune, file/param change); the render
+    // key only captures view geometry, so without this a retune would re-blit a
+    // stale histogram.
+    void invalidateEvent() override;
 
     // Public so the file-scope worker render helper can take it by value.
     struct RenderKey {
@@ -36,14 +40,17 @@ public:
         size_t len = 0;
         int w = 0;
         int h = 0;
+        unsigned epoch = 0;
         bool operator==(const RenderKey &o) const {
-            return start == o.start && len == o.len && w == o.w && h == o.h;
+            return start == o.start && len == o.len && w == o.w && h == o.h &&
+                   epoch == o.epoch;
         }
         bool operator!=(const RenderKey &o) const { return !(*this == o); }
     };
 
 private:
     std::shared_ptr<SampleSource<float>> floatSource;
+    unsigned dataEpoch_ = 0;
     bool selectionEnabled = false;
     range_t<size_t> selectedRange{0, 0};
 

--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -276,6 +276,15 @@ static std::vector<TarEntry> parseTar(const uchar *data, qint64 totalSize)
         char typeflag = hdr[156];
 
         qint64 dataStart = pos + 512;
+        // Bound the payload against the actual mapping. A truncated or hostile
+        // tar can carry a size field that runs past the mmap, and the
+        // downstream QByteArray / copyRange reads would then walk off the
+        // mapping (SIGSEGV/SIGBUS). dataStart <= totalSize already (loop
+        // guard), so this is the overflow-safe form. Stop parsing on a bad
+        // size — once the framing is wrong the rest of the stream can't be
+        // trusted anyway.
+        if (sz < 0 || sz > totalSize - dataStart)
+            break;
         // Only regular files ('0' in ustar, '\0' in very old tar) carry data
         // we care about; skip directories, links, etc.
         if (typeflag == '0' || typeflag == '\0') {
@@ -626,7 +635,7 @@ void InputSource::openIqTar(const uchar *data, qint64 size)
     frequency = centerFreq;
 }
 
-void InputSource::openSigmfArchive(const uchar *data, qint64 size)
+bool InputSource::openSigmfArchive(const uchar *data, qint64 size)
 {
     auto entries = parseTar(data, size);
 
@@ -636,10 +645,12 @@ void InputSource::openSigmfArchive(const uchar *data, qint64 size)
         if (e.name.endsWith(".sigmf-meta", Qt::CaseInsensitive)) metaEntry = &e;
         else if (e.name.endsWith(".sigmf-data", Qt::CaseInsensitive)) dataEntry = &e;
     }
-    if (!metaEntry)
-        throw std::runtime_error("sigmf archive: no .sigmf-meta found in archive");
-    if (!dataEntry)
-        throw std::runtime_error("sigmf archive: no .sigmf-data found in archive");
+    // Not a SigMF archive (no meta/data members). Report that rather than
+    // throwing so the caller can fall back — e.g. a plain `.tar` then opens
+    // as raw IQ instead of failing. A genuinely malformed `.sigmf` is the
+    // caller's error to raise.
+    if (!metaEntry || !dataEntry)
+        return false;
 
     QByteArray metaBytes(reinterpret_cast<const char*>(data + metaEntry->dataOffset),
                          static_cast<int>(metaEntry->size));
@@ -649,6 +660,7 @@ void InputSource::openSigmfArchive(const uchar *data, qint64 size)
 
     dataOffset = static_cast<size_t>(dataEntry->dataOffset);
     sampleCount = dataEntry->size / sampleAdapter->sampleSize();
+    return true;
 }
 
 void InputSource::openFile(const char *filename)
@@ -658,6 +670,12 @@ void InputSource::openFile(const char *filename)
     _wasSigmfInput = false;
     _originalSigmfRoot = QJsonObject();
     _annotationsDirty = false;
+    // Reset the center frequency for each open. Container metadata (SigMF,
+    // iq.tar) raises it again below when present; filename-derived values
+    // (gqrx/osmocom) are applied by MainWindow *after* openFile() returns.
+    // Without this reset a baseband file opened after a frequency-tagged one
+    // would inherit the previous file's center and mislabel the abs-freq axis.
+    frequency = 0.0;
     std::string suffix = std::string(fileInfo.suffix().toLower().toUtf8().constData());
     if (_fmt != "") { suffix = _fmt; } // allow fmt override
 
@@ -799,18 +817,30 @@ void InputSource::openFile(const char *filename)
 
         annotationList.clear();
         dataOffset = 0;
+        bool handled = false;
         try {
-            openSigmfArchive(data, archiveSize);
+            handled = openSigmfArchive(data, archiveSize);
         } catch (...) {
             file->unmap(data);
             throw;
         }
 
-        cleanup();
-        inputFile = file.release();
-        mmapData = data;
-        invalidate();
-        return;
+        if (handled) {
+            cleanup();
+            inputFile = file.release();
+            mmapData = data;
+            invalidate();
+            return;
+        }
+
+        // The archive carried no .sigmf-meta/.sigmf-data. Drop the mapping;
+        // for a plain `.tar` fall through to the raw path (preserving the
+        // pre-existing "open as raw IQ" behavior), but a `.sigmf` that isn't
+        // a valid archive is a hard error.
+        file->unmap(data);
+        if (suffix != "tar")
+            throw std::runtime_error("sigmf archive: no .sigmf-meta/.sigmf-data found in archive");
+        dataFilename = filename;
     }
     else {
         dataFilename = filename;

--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -676,6 +676,11 @@ void InputSource::openFile(const char *filename)
     // Without this reset a baseband file opened after a frequency-tagged one
     // would inherit the previous file's center and mislabel the abs-freq axis.
     frequency = 0.0;
+    // Likewise reset the real-signal flag: the format branches below (and the
+    // container paths) set it true where appropriate, but a complex file
+    // opened after a real one would otherwise inherit the stale true and get a
+    // single-sided spectrogram. (The plain-.tar→cf32 fallback relies on this.)
+    _realSignal = false;
     std::string suffix = std::string(fileInfo.suffix().toLower().toUtf8().constData());
     if (_fmt != "") { suffix = _fmt; } // allow fmt override
 

--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -397,6 +397,7 @@ static QString decompressZstToCache(const QFileInfo &zstInfo)
 
 InputSource::InputSource()
 {
+    frequency = 0.0;
 }
 
 InputSource::~InputSource()
@@ -781,10 +782,12 @@ void InputSource::openFile(const char *filename)
             }
         }
     }
-    else if (suffix == "sigmf") {
-        // SigMF archive (ustar bundling a .sigmf-meta + .sigmf-data). Parse it
-        // in place like iq.tar — the data is read at its offset inside the
-        // mmap'd archive, so there's no separate extraction copy.
+    else if (suffix == "sigmf" || suffix == "tar") {
+        // SigMF archive (ustar bundling a .sigmf-meta + .sigmf-data). IQEngine
+        // uses .tar.zst, which decompresses to .tar, so accept both the SigMF
+        // archive suffix and a plain tar suffix here. Parse it in place like
+        // iq.tar — the data is read at its offset inside the mmap'd archive,
+        // so there's no separate extraction copy.
         auto file = std::make_unique<QFile>(filename);
         if (!file->open(QFile::ReadOnly)) {
             throw std::runtime_error(file->errorString().toStdString());

--- a/src/inputsource.h
+++ b/src/inputsource.h
@@ -74,7 +74,10 @@ private:
     // tarball bundling a .sigmf-meta + .sigmf-data, optionally produced by
     // decompressing a .sigmf.zst). The data is read in place at its byte
     // offset within the archive, so no separate extraction copy is made.
-    void openSigmfArchive(const uchar *data, qint64 size);
+    // Returns true if it was a SigMF archive and the fields were populated;
+    // false if it carried no .sigmf-meta/.sigmf-data (so the caller can fall
+    // back, e.g. open a plain `.tar` as raw IQ).
+    bool openSigmfArchive(const uchar *data, qint64 size);
 
 public:
     InputSource();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -142,12 +142,17 @@ void MainWindow::openFile(QString fileName)
     // gqrx capture filename: gqrx_<YYYYMMDD>_<HHMMSS>_<centerfreqHz>_<sampleRateHz>_fc.raw
     // Example: gqrx_20260429_031912_251580000_10000000_fc.raw
     // Both fields are integer Hz, so a clean regex+toDouble round-trip works.
+    // The gqrx center frequency is applied *after* openFile() so the per-open
+    // frequency reset inside openFile() (which clears the previous file's
+    // center) doesn't clobber it. Sample rate is safe to set first — openFile
+    // only overwrites it from container metadata, which gqrx .raw lacks.
+    double pendingCenterHz = 0.0;
     QRegExp gqrxRx("gqrx_\\d{8}_\\d{6}_(\\d+)_(\\d+)_fc\\.raw");
     if (gqrxRx.exactMatch(basename)) {
         bool ok = false;
         double centerHz = gqrxRx.cap(1).toDouble(&ok);
         if (ok && centerHz > 0.0) {
-            input->setCenterFrequency(centerHz);
+            pendingCenterHz = centerHz;
         }
         double rateHz = gqrxRx.cap(2).toDouble(&ok);
         if (ok && rateHz > 0.0) {
@@ -158,6 +163,9 @@ void MainWindow::openFile(QString fileName)
     try
     {
         input->openFile(fileName.toUtf8().constData());
+        if (pendingCenterHz > 0.0) {
+            input->setCenterFrequency(pendingCenterHz);
+        }
     }
     catch (const std::exception &ex)
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -74,6 +74,8 @@ MainWindow::MainWindow()
     connect(dock, &SpectrogramControls::fmLpfMethodChanged, plots, &PlotView::setFmLpfMethod);
     connect(dock, &SpectrogramControls::fmDecimChanged, plots, &PlotView::setFmDecimation);
     connect(dock, &SpectrogramControls::fmPredemodDecimChanged, plots, &PlotView::setFmPredemodDecimation);
+    // FM amplitude squelch (% of window-peak |IQ|).
+    connect(dock, &SpectrogramControls::fmSquelchChanged, plots, &PlotView::setFmSquelch);
     // Symbol rate (Bd) for the FSK polar plot's differential delay.
     connect(dock, &SpectrogramControls::symbolRateChanged, plots, &PlotView::setSymbolRate);
     // Signal-strength gate (%) for the FSK polar constellation.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -74,6 +74,8 @@ MainWindow::MainWindow()
     connect(dock, &SpectrogramControls::fmLpfMethodChanged, plots, &PlotView::setFmLpfMethod);
     connect(dock, &SpectrogramControls::fmDecimChanged, plots, &PlotView::setFmDecimation);
     connect(dock, &SpectrogramControls::fmPredemodDecimChanged, plots, &PlotView::setFmPredemodDecimation);
+    // Symbol rate (Bd) for the FSK polar plot's differential delay.
+    connect(dock, &SpectrogramControls::symbolRateChanged, plots, &PlotView::setSymbolRate);
     // Auto-tune button: dock asks PlotView, PlotView picks values and applies
     // them, then echoes them back so the dock widgets reflect the new state.
     connect(dock, &SpectrogramControls::autoLpfRequested, plots, &PlotView::autoTuneFmLpf);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -76,6 +76,8 @@ MainWindow::MainWindow()
     connect(dock, &SpectrogramControls::fmPredemodDecimChanged, plots, &PlotView::setFmPredemodDecimation);
     // Symbol rate (Bd) for the FSK polar plot's differential delay.
     connect(dock, &SpectrogramControls::symbolRateChanged, plots, &PlotView::setSymbolRate);
+    // Signal-strength gate (%) for the FSK polar constellation.
+    connect(dock, &SpectrogramControls::constellationGateChanged, plots, &PlotView::setConstellationGate);
     // Auto-tune button: dock asks PlotView, PlotView picks values and applies
     // them, then echoes them back so the dock widgets reflect the new state.
     connect(dock, &SpectrogramControls::autoLpfRequested, plots, &PlotView::autoTuneFmLpf);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -78,6 +78,8 @@ MainWindow::MainWindow()
     connect(dock, &SpectrogramControls::symbolRateChanged, plots, &PlotView::setSymbolRate);
     // Signal-strength gate (%) for the FSK polar constellation.
     connect(dock, &SpectrogramControls::constellationGateChanged, plots, &PlotView::setConstellationGate);
+    // Symbol-timed (1 point/symbol) FSK polar constellation toggle.
+    connect(dock, &SpectrogramControls::constellationSymbolTimedChanged, plots, &PlotView::setConstellationSymbolTimed);
     // Auto-tune button: dock asks PlotView, PlotView picks values and applies
     // them, then echoes them back so the dock widgets reflect the new state.
     connect(dock, &SpectrogramControls::autoLpfRequested, plots, &PlotView::autoTuneFmLpf);

--- a/src/phasedemod.h
+++ b/src/phasedemod.h
@@ -26,4 +26,5 @@ class PhaseDemod : public SampleBuffer<std::complex<float>, float>
 public:
     PhaseDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
     void work(void *input, void *output, int count, size_t sampleid) override;
+    bool workIsReentrant() override { return true; } // stateless arg(x) map
 };

--- a/src/plots.cpp
+++ b/src/plots.cpp
@@ -19,6 +19,8 @@
 
 #include "amplitudedemod.h"
 #include "frequencydemod.h"
+#include "fskdemod.h"
+#include "fskpolarplot.h"
 #include "phasedemod.h"
 #include "threshold.h"
 #include "traceplot.h"
@@ -52,6 +54,20 @@ Plot* Plots::phasePlot(std::shared_ptr<AbstractSampleSource> source)
     typedef SampleSource<std::complex<float>> Source;
     std::shared_ptr<Source> concrete = std::dynamic_pointer_cast<Source>(source);
     return new TracePlot(std::make_shared<PhaseDemod>(concrete));
+}
+
+Plot* Plots::fskPlot(std::shared_ptr<AbstractSampleSource> source)
+{
+    typedef SampleSource<std::complex<float>> Source;
+    std::shared_ptr<Source> concrete = std::dynamic_pointer_cast<Source>(source);
+    return new TracePlot(std::make_shared<FskDemod>(concrete));
+}
+
+Plot* Plots::fskPolarPlot(std::shared_ptr<AbstractSampleSource> source)
+{
+    typedef SampleSource<std::complex<float>> Source;
+    std::shared_ptr<Source> concrete = std::dynamic_pointer_cast<Source>(source);
+    return new FskPolarPlot(concrete);
 }
 
 Plot* Plots::thresholdPlot(std::shared_ptr<AbstractSampleSource> source)

--- a/src/plots.cpp
+++ b/src/plots.cpp
@@ -21,6 +21,7 @@
 #include "frequencydemod.h"
 #include "fskdemod.h"
 #include "fskpolarplot.h"
+#include "histogramplot.h"
 #include "phasedemod.h"
 #include "threshold.h"
 #include "traceplot.h"
@@ -75,4 +76,11 @@ Plot* Plots::thresholdPlot(std::shared_ptr<AbstractSampleSource> source)
     typedef SampleSource<float> Source;
     std::shared_ptr<Source> concrete= std::dynamic_pointer_cast<Source>(source);
     return new TracePlot( std::make_shared<Threshold>( concrete ) );
+}
+
+Plot* Plots::histogramPlot(std::shared_ptr<AbstractSampleSource> source)
+{
+    typedef SampleSource<float> Source;
+    std::shared_ptr<Source> concrete = std::dynamic_pointer_cast<Source>(source);
+    return new HistogramPlot(concrete);
 }

--- a/src/plots.h
+++ b/src/plots.h
@@ -40,6 +40,8 @@ public:
     static Plot* amplitudePlot(std::shared_ptr<AbstractSampleSource> source);
     static Plot* frequencyPlot(std::shared_ptr<AbstractSampleSource> source);
     static Plot* phasePlot(std::shared_ptr<AbstractSampleSource> source);
+    static Plot* fskPlot(std::shared_ptr<AbstractSampleSource> source);
+    static Plot* fskPolarPlot(std::shared_ptr<AbstractSampleSource> source);
     static Plot* thresholdPlot(std::shared_ptr<AbstractSampleSource> source);
 
     static class _init
@@ -49,6 +51,8 @@ public:
             plots.emplace(typeid(std::complex<float>), PlotInfo{"sample plot", samplePlot});
             plots.emplace(typeid(std::complex<float>), PlotInfo{"amplitude plot", amplitudePlot});
             plots.emplace(typeid(std::complex<float>), PlotInfo{"frequency plot", frequencyPlot});
+            plots.emplace(typeid(std::complex<float>), PlotInfo{"FSK plot", fskPlot});
+            plots.emplace(typeid(std::complex<float>), PlotInfo{"FSK polar plot", fskPolarPlot});
             plots.emplace(typeid(std::complex<float>), PlotInfo{"phase plot", phasePlot});
             plots.emplace(typeid(float), PlotInfo{"threshold plot", thresholdPlot});
         };

--- a/src/plots.h
+++ b/src/plots.h
@@ -43,6 +43,7 @@ public:
     static Plot* fskPlot(std::shared_ptr<AbstractSampleSource> source);
     static Plot* fskPolarPlot(std::shared_ptr<AbstractSampleSource> source);
     static Plot* thresholdPlot(std::shared_ptr<AbstractSampleSource> source);
+    static Plot* histogramPlot(std::shared_ptr<AbstractSampleSource> source);
 
     static class _init
     {
@@ -55,6 +56,7 @@ public:
             plots.emplace(typeid(std::complex<float>), PlotInfo{"FSK polar plot", fskPolarPlot});
             plots.emplace(typeid(std::complex<float>), PlotInfo{"phase plot", phasePlot});
             plots.emplace(typeid(float), PlotInfo{"threshold plot", thresholdPlot});
+            plots.emplace(typeid(float), PlotInfo{"value histogram", histogramPlot});
         };
     } _initializer;
 };

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -22,6 +22,7 @@
 #include "frequencydemod.h"
 #include "fskdemod.h"
 #include "fskpolarplot.h"
+#include "histogramplot.h"
 #include "util.h"
 #include <QPixmapCache>
 #include <climits>
@@ -420,6 +421,9 @@ void PlotView::addPlot(Plot *plot)
         fskp->setSymbolRate(symbolRateHz);
         fskp->setSelection(cursorsEnabled, selectedSamples);
     }
+    if (auto hist = dynamic_cast<HistogramPlot*>(plot)) {
+        hist->setSelection(cursorsEnabled, selectedSamples);
+    }
     connect(plot, &Plot::repaint, this, &PlotView::repaint);
 }
 
@@ -757,11 +761,16 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
 }
 
 
-void PlotView::updateFskPolarSelections()
+void PlotView::updateSelectionPlots()
 {
+    // Plots that summarise the cursor selection (or the visible range when
+    // cursors are off) rather than tracking time: keep their range in sync.
     for (auto &plt : plots) {
         if (auto fskp = dynamic_cast<FskPolarPlot*>(plt.get())) {
             fskp->setSelection(cursorsEnabled, selectedSamples);
+        }
+        if (auto hist = dynamic_cast<HistogramPlot*>(plt.get())) {
+            hist->setSelection(cursorsEnabled, selectedSamples);
         }
     }
 }
@@ -773,7 +782,7 @@ void PlotView::cursorsMoved()
         columnToSample(horizontalScrollBar()->value() + cursors.selection().maximum)
     };
 
-    updateFskPolarSelections();
+    updateSelectionPlots();
     emitTimeSelection();
     viewport()->update();
 }
@@ -793,7 +802,7 @@ void PlotView::enableCursors(bool enabled)
         cursors.setSelection({viewport()->rect().left() + margin, viewport()->rect().right() - margin});
         cursorsMoved();
     } else {
-        updateFskPolarSelections();
+        updateSelectionPlots();
     }
     viewport()->update();
 }
@@ -1367,7 +1376,7 @@ void PlotView::setCursorSegments(int segments)
 
     // Keep any FSK polar plot's selected range in sync — cursorsMoved() and
     // enableCursors() both do this, and resegmenting mutates selectedSamples too.
-    updateFskPolarSelections();
+    updateSelectionPlots();
     updateView();
     emitTimeSelection();
 }

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -20,6 +20,8 @@
 #include "plotview.h"
 #include "annotationdialog.h"
 #include "frequencydemod.h"
+#include "fskdemod.h"
+#include "fskpolarplot.h"
 #include "util.h"
 #include <QPixmapCache>
 #include <climits>
@@ -95,6 +97,7 @@ PlotView::PlotView(InputSource *input) : cursors(this), viewRange({0, 0}), deriv
 
 void PlotView::enableFastDemod(bool enabled)
 {
+    fmFastDemod = enabled;
     // clear any cached trace tiles so new demod data is used
     QPixmapCache::clear();
     // walk all derived TracePlot instances and update their demod mode
@@ -103,6 +106,9 @@ void PlotView::enableFastDemod(bool enabled)
             auto src = tp->source();
             if (auto fd = dynamic_cast<FrequencyDemod*>(src.get())) {
                 fd->setCheapDemod(enabled);
+            }
+            if (auto fsk = dynamic_cast<FskDemod*>(src.get())) {
+                fsk->setCheapDemod(enabled);
             }
         }
     }
@@ -121,9 +127,16 @@ void PlotView::setFmLpfCutoff(double hz)
     fmLpfCutoffHz = hz;
     for (auto &plt : plots) {
         if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
-            if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
+            auto src = tp->source();
+            if (auto fd = dynamic_cast<FrequencyDemod*>(src.get())) {
                 fd->setPostLpfCutoff(hz);
             }
+            if (auto fsk = dynamic_cast<FskDemod*>(src.get())) {
+                fsk->setPostLpfCutoff(hz);
+            }
+        }
+        if (auto fskp = dynamic_cast<FskPolarPlot*>(plt.get())) {
+            fskp->setReferenceCutoff(hz);
         }
     }
     QPixmapCache::clear();
@@ -137,8 +150,12 @@ void PlotView::setFmDecimation(int n)
     fmDecim = n;
     for (auto &plt : plots) {
         if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
-            if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
+            auto src = tp->source();
+            if (auto fd = dynamic_cast<FrequencyDemod*>(src.get())) {
                 fd->setPostDecimation(n);
+            }
+            if (auto fsk = dynamic_cast<FskDemod*>(src.get())) {
+                fsk->setPostDecimation(n);
             }
         }
     }
@@ -153,8 +170,12 @@ void PlotView::setFmLpfMethod(int method)
     auto m = static_cast<FrequencyDemod::LpfMethod>(method);
     for (auto &plt : plots) {
         if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
-            if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
+            auto src = tp->source();
+            if (auto fd = dynamic_cast<FrequencyDemod*>(src.get())) {
                 fd->setPostLpfMethod(m);
+            }
+            if (auto fsk = dynamic_cast<FskDemod*>(src.get())) {
+                fsk->setPostLpfMethod(m);
             }
         }
     }
@@ -169,8 +190,12 @@ void PlotView::setFmPredemodDecimation(int m)
     fmPredemodDecim = m;
     for (auto &plt : plots) {
         if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
-            if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
+            auto src = tp->source();
+            if (auto fd = dynamic_cast<FrequencyDemod*>(src.get())) {
                 fd->setPredemodDecimation(m);
+            }
+            if (auto fsk = dynamic_cast<FskDemod*>(src.get())) {
+                fsk->setPredemodDecimation(m);
             }
         }
     }
@@ -364,14 +389,26 @@ void PlotView::addPlot(Plot *plot)
     if (plots.size() > 1) {
         plot->setPlotHeight(derivedPlotHeight);
     }
-    // Propagate the currently-configured FM settings to any newly added FM plot.
+    // Propagate the currently-configured FM settings to newly added FM/FSK plots.
     if (auto tp = dynamic_cast<TracePlot*>(plot)) {
         if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get())) {
             fd->setPostLpfMethod(static_cast<FrequencyDemod::LpfMethod>(fmLpfMethod));
             fd->setPostLpfCutoff(fmLpfCutoffHz);
             fd->setPostDecimation(fmDecim);
             fd->setPredemodDecimation(fmPredemodDecim);
+            fd->setCheapDemod(fmFastDemod);
         }
+        if (auto fsk = dynamic_cast<FskDemod*>(tp->source().get())) {
+            fsk->setPostLpfMethod(static_cast<FrequencyDemod::LpfMethod>(fmLpfMethod));
+            fsk->setPostLpfCutoff(fmLpfCutoffHz);
+            fsk->setPostDecimation(fmDecim);
+            fsk->setPredemodDecimation(fmPredemodDecim);
+            fsk->setCheapDemod(fmFastDemod);
+        }
+    }
+    if (auto fskp = dynamic_cast<FskPolarPlot*>(plot)) {
+        fskp->setReferenceCutoff(fmLpfCutoffHz);
+        fskp->setSelection(cursorsEnabled, selectedSamples);
     }
     connect(plot, &Plot::repaint, this, &PlotView::repaint);
 }
@@ -709,6 +746,16 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
         updateView(false);
 }
 
+
+void PlotView::updateFskPolarSelections()
+{
+    for (auto &plt : plots) {
+        if (auto fskp = dynamic_cast<FskPolarPlot*>(plt.get())) {
+            fskp->setSelection(cursorsEnabled, selectedSamples);
+        }
+    }
+}
+
 void PlotView::cursorsMoved()
 {
     selectedSamples = {
@@ -716,6 +763,7 @@ void PlotView::cursorsMoved()
         columnToSample(horizontalScrollBar()->value() + cursors.selection().maximum)
     };
 
+    updateFskPolarSelections();
     emitTimeSelection();
     viewport()->update();
 }
@@ -734,6 +782,8 @@ void PlotView::enableCursors(bool enabled)
         int margin = viewport()->rect().width() / 3;
         cursors.setSelection({viewport()->rect().left() + margin, viewport()->rect().right() - margin});
         cursorsMoved();
+    } else {
+        updateFskPolarSelections();
     }
     viewport()->update();
 }

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -155,6 +155,17 @@ void PlotView::setSymbolRate(double baud)
     }
 }
 
+// Signal-strength gate (% of window peak) for the FSK polar plot's scope.
+void PlotView::setConstellationGate(int pct)
+{
+    constellationGatePct = pct;
+    for (auto &plt : plots) {
+        if (auto fskp = dynamic_cast<FskPolarPlot*>(plt.get())) {
+            fskp->setLevelGate(pct);
+        }
+    }
+}
+
 void PlotView::setFmDecimation(int n)
 {
     if (n < 1) n = 1;
@@ -419,6 +430,7 @@ void PlotView::addPlot(Plot *plot)
     }
     if (auto fskp = dynamic_cast<FskPolarPlot*>(plot)) {
         fskp->setSymbolRate(symbolRateHz);
+        fskp->setLevelGate(constellationGatePct);
         fskp->setSelection(cursorsEnabled, selectedSamples);
     }
     if (auto hist = dynamic_cast<HistogramPlot*>(plot)) {

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -237,6 +237,22 @@ void PlotView::setFmPredemodDecimation(int m)
     if (periodTimer) periodTimer->start();
 }
 
+// Amplitude squelch (% of window-peak |IQ|) for every FM plot. Blanks the
+// discriminator output in the noise gaps so it stops dominating the autoscale.
+void PlotView::setFmSquelch(int pct)
+{
+    fmSquelchPct = pct;
+    for (auto &plt : plots) {
+        if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
+            if (auto fd = dynamic_cast<FrequencyDemod*>(tp->source().get()))
+                fd->setAmplitudeSquelch(pct / 100.0);
+        }
+    }
+    QPixmapCache::clear();
+    viewport()->update();
+    if (periodTimer) periodTimer->start();
+}
+
 void PlotView::autoTuneFmLpf()
 {
     if (!spectrogramPlot || sampleRate <= 0.0) return;
@@ -430,6 +446,7 @@ void PlotView::addPlot(Plot *plot)
             fd->setPostDecimation(fmDecim);
             fd->setPredemodDecimation(fmPredemodDecim);
             fd->setCheapDemod(fmFastDemod);
+            fd->setAmplitudeSquelch(fmSquelchPct / 100.0);
         }
         if (auto fsk = dynamic_cast<FskDemod*>(tp->source().get())) {
             fsk->setPostLpfMethod(static_cast<FrequencyDemod::LpfMethod>(fmLpfMethod));

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -135,13 +135,23 @@ void PlotView::setFmLpfCutoff(double hz)
                 fsk->setPostLpfCutoff(hz);
             }
         }
-        if (auto fskp = dynamic_cast<FskPolarPlot*>(plt.get())) {
-            fskp->setReferenceCutoff(hz);
-        }
     }
     QPixmapCache::clear();
     viewport()->update();
     if (periodTimer) periodTimer->start();
+}
+
+// Symbol rate (baud) for the differential constellation. Kept separate from
+// the FM LPF cutoff: the polar delay is a symbol-period quantity, not a filter
+// bandwidth, and conflating them reshaped the FM trace as a side effect.
+void PlotView::setSymbolRate(double baud)
+{
+    symbolRateHz = baud;
+    for (auto &plt : plots) {
+        if (auto fskp = dynamic_cast<FskPolarPlot*>(plt.get())) {
+            fskp->setSymbolRate(baud);
+        }
+    }
 }
 
 void PlotView::setFmDecimation(int n)
@@ -407,7 +417,7 @@ void PlotView::addPlot(Plot *plot)
         }
     }
     if (auto fskp = dynamic_cast<FskPolarPlot*>(plot)) {
-        fskp->setReferenceCutoff(fmLpfCutoffHz);
+        fskp->setSymbolRate(symbolRateHz);
         fskp->setSelection(cursorsEnabled, selectedSamples);
     }
     connect(plot, &Plot::repaint, this, &PlotView::repaint);
@@ -1355,6 +1365,9 @@ void PlotView::setCursorSegments(int segments)
 
     cursors.setSegments(segments);
 
+    // Keep any FSK polar plot's selected range in sync — cursorsMoved() and
+    // enableCursors() both do this, and resegmenting mutates selectedSamples too.
+    updateFskPolarSelections();
     updateView();
     emitTimeSelection();
 }

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -166,6 +166,17 @@ void PlotView::setConstellationGate(int pct)
     }
 }
 
+// Toggle symbol-timed (1 point/symbol) vs full-rate constellation rendering.
+void PlotView::setConstellationSymbolTimed(bool on)
+{
+    constellationSymbolTimed = on;
+    for (auto &plt : plots) {
+        if (auto fskp = dynamic_cast<FskPolarPlot*>(plt.get())) {
+            fskp->setSymbolTimed(on);
+        }
+    }
+}
+
 void PlotView::setFmDecimation(int n)
 {
     if (n < 1) n = 1;
@@ -431,6 +442,7 @@ void PlotView::addPlot(Plot *plot)
     if (auto fskp = dynamic_cast<FskPolarPlot*>(plot)) {
         fskp->setSymbolRate(symbolRateHz);
         fskp->setLevelGate(constellationGatePct);
+        fskp->setSymbolTimed(constellationSymbolTimed);
         fskp->setSelection(cursorsEnabled, selectedSamples);
     }
     if (auto hist = dynamic_cast<HistogramPlot*>(plot)) {

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -175,11 +175,13 @@ private:
     QTimer *periodTimer = nullptr;
     bool   periodAnalysisEnabled = false;
     void analyzeVisiblePeriod();
+    void updateFskPolarSelections();
     // Latest-applied FM post-demod settings; re-applied when new FM plots are added.
     double fmLpfCutoffHz = 0.0;
     int    fmLpfMethod = 0; // FrequencyDemod::LpfMethod::KaiserFir
     int    fmDecim = 1;
     int    fmPredemodDecim = 1;
+    bool   fmFastDemod = false;
     // Shift+left-drag annotation rubber-banding on the spectrogram. The
     // rectangle is in viewport coords; on release we map x→sample range and
     // y→absolute Hz range, then open AnnotationDialog.

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -93,6 +93,8 @@ public slots:
     void setFmDecimation(int n);
     // Pre-demod IQ decimation factor (1 = off).
     void setFmPredemodDecimation(int m);
+    // Amplitude squelch (% of window-peak |IQ|) for every FM plot. 0 = off.
+    void setFmSquelch(int pct);
     // Symbol rate (baud) for the FSK polar plot's differential delay. 0 = unset.
     void setSymbolRate(double baud);
     // Signal-strength gate (% of window peak) for the FSK polar constellation.
@@ -188,6 +190,7 @@ private:
     int    fmDecim = 1;
     int    fmPredemodDecim = 1;
     bool   fmFastDemod = false;
+    int    fmSquelchPct = 0; // amplitude squelch (% of window-peak |IQ|), 0 = off
     // Symbol rate (baud) re-applied to FSK polar plots as they're added. 0 = unset.
     double symbolRateHz = 0.0;
     // Constellation signal-strength gate (% of window peak), re-applied likewise.

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -95,6 +95,8 @@ public slots:
     void setFmPredemodDecimation(int m);
     // Symbol rate (baud) for the FSK polar plot's differential delay. 0 = unset.
     void setSymbolRate(double baud);
+    // Signal-strength gate (% of window peak) for the FSK polar constellation.
+    void setConstellationGate(int pct);
     // Pick reasonable LPF cutoff, predemod M, and post N from the current
     // sample rate and tuner bandwidth. Applies them and emits
     // fmAutoLpfComputed() so the dock widgets can mirror.
@@ -186,6 +188,8 @@ private:
     bool   fmFastDemod = false;
     // Symbol rate (baud) re-applied to FSK polar plots as they're added. 0 = unset.
     double symbolRateHz = 0.0;
+    // Constellation signal-strength gate (% of window peak), re-applied likewise.
+    int    constellationGatePct = 15;
     // Shift+left-drag annotation rubber-banding on the spectrogram. The
     // rectangle is in viewport coords; on release we map x→sample range and
     // y→absolute Hz range, then open AnnotationDialog.

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -93,6 +93,8 @@ public slots:
     void setFmDecimation(int n);
     // Pre-demod IQ decimation factor (1 = off).
     void setFmPredemodDecimation(int m);
+    // Symbol rate (baud) for the FSK polar plot's differential delay. 0 = unset.
+    void setSymbolRate(double baud);
     // Pick reasonable LPF cutoff, predemod M, and post N from the current
     // sample rate and tuner bandwidth. Applies them and emits
     // fmAutoLpfComputed() so the dock widgets can mirror.
@@ -182,6 +184,8 @@ private:
     int    fmDecim = 1;
     int    fmPredemodDecim = 1;
     bool   fmFastDemod = false;
+    // Symbol rate (baud) re-applied to FSK polar plots as they're added. 0 = unset.
+    double symbolRateHz = 0.0;
     // Shift+left-drag annotation rubber-banding on the spectrogram. The
     // rectangle is in viewport coords; on release we map x→sample range and
     // y→absolute Hz range, then open AnnotationDialog.

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -97,6 +97,8 @@ public slots:
     void setSymbolRate(double baud);
     // Signal-strength gate (% of window peak) for the FSK polar constellation.
     void setConstellationGate(int pct);
+    // Symbol-timed (1 point/symbol) vs full-rate FSK polar constellation.
+    void setConstellationSymbolTimed(bool on);
     // Pick reasonable LPF cutoff, predemod M, and post N from the current
     // sample rate and tuner bandwidth. Applies them and emits
     // fmAutoLpfComputed() so the dock widgets can mirror.
@@ -190,6 +192,8 @@ private:
     double symbolRateHz = 0.0;
     // Constellation signal-strength gate (% of window peak), re-applied likewise.
     int    constellationGatePct = 15;
+    // Symbol-timed constellation rendering, re-applied to new FSK polar plots.
+    bool   constellationSymbolTimed = true;
     // Shift+left-drag annotation rubber-banding on the spectrogram. The
     // rectangle is in viewport coords; on release we map x→sample range and
     // y→absolute Hz range, then open AnnotationDialog.

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -177,7 +177,7 @@ private:
     QTimer *periodTimer = nullptr;
     bool   periodAnalysisEnabled = false;
     void analyzeVisiblePeriod();
-    void updateFskPolarSelections();
+    void updateSelectionPlots();
     // Latest-applied FM post-demod settings; re-applied when new FM plots are added.
     double fmLpfCutoffHz = 0.0;
     int    fmLpfMethod = 0; // FrequencyDemod::LpfMethod::KaiserFir

--- a/src/samplebuffer.cpp
+++ b/src/samplebuffer.cpp
@@ -43,11 +43,19 @@ std::unique_ptr<Tout[]> SampleBuffer<Tin, Tout>::getSamples(size_t start, size_t
 
     auto temp = std::make_unique<Tout[]>(history + length);
     auto dest = std::make_unique<Tout[]>(length);
-    QMutexLocker ml(&mutex);
     // Pass the sampleid of the buffer's first sample (start - history), not of
     // the returned output, so NCO-based transforms like TunerTransform can set
     // their phase consistently with what they actually mix.
-    work(samples.get(), temp.get(), history + length, start - history);
+    //
+    // Reentrant nodes (stateless work()) run lock-free so concurrent tile
+    // workers transforming the same shared node don't serialise on `mutex`;
+    // stateful nodes (FrequencyDemod, ...) keep the lock.
+    if (workIsReentrant()) {
+        work(samples.get(), temp.get(), history + length, start - history);
+    } else {
+        QMutexLocker ml(&mutex);
+        work(samples.get(), temp.get(), history + length, start - history);
+    }
     memcpy(dest.get(), temp.get() + history, length * sizeof(Tout));
     return dest;
 }

--- a/src/samplebuffer.h
+++ b/src/samplebuffer.h
@@ -44,6 +44,12 @@ public:
     void invalidateEvent();
     virtual std::unique_ptr<Tout[]> getSamples(size_t start, size_t length);
     virtual void work(void *input, void *output, int count, size_t sampleid) = 0;
+    // Override to return true when work() carries no mutable per-instance state
+    // (only locals + its own parameter snapshot). getSamples() then runs it
+    // WITHOUT taking `mutex`, so many tile workers can transform the same shared
+    // node concurrently instead of serialising on it. Default false (safe):
+    // stateful nodes like FrequencyDemod keep the lock.
+    virtual bool workIsReentrant() { return false; }
     virtual size_t count() {
         return src->count();
     };

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -356,6 +356,19 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     connect(constellationGateSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this, &SpectrogramControls::constellationGateChanged);
 
+    // Symbol-timed constellation: resample to one point per symbol (using the
+    // symbol rate above) so the inter-symbol trajectory spokes collapse into
+    // clean decision-point clusters. Off shows the full-rate trajectory.
+    constellationSymbolTimedCheckBox = new QCheckBox(widget);
+    constellationSymbolTimedCheckBox->setChecked(true);
+    constellationSymbolTimedCheckBox->setToolTip(tr(
+        "Sample the FSK polar plot once per symbol (timing recovered) so the "
+        "constellation shows decision-point clusters instead of the full-rate "
+        "trajectory. Needs a valid symbol rate."));
+    layout->addRow(new QLabel(tr("Constellation symbol-timed:")), constellationSymbolTimedCheckBox);
+    connect(constellationSymbolTimedCheckBox, &QCheckBox::toggled,
+            this, &SpectrogramControls::constellationSymbolTimedChanged);
+
     widget->setLayout(layout);
     setWidget(widget);
 

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -294,6 +294,20 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     layout->addRow(new QLabel(tr("FM decim (N):")), fmDecimSpinBox);
     connect(fmDecimSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this, &SpectrogramControls::fmDecimChanged);
+    // FM amplitude squelch: blank the discriminator output where the carrier
+    // amplitude is below this % of the window peak, so noise in the gaps
+    // between bursts stops dominating the FM trace's autoscale. 0 = off.
+    fmSquelchSpinBox = new QSpinBox(widget);
+    fmSquelchSpinBox->setRange(0, 100);
+    fmSquelchSpinBox->setValue(0);
+    fmSquelchSpinBox->setSuffix("%");
+    fmSquelchSpinBox->setToolTip(tr(
+        "Blank the FM trace where the carrier amplitude |IQ| is below this "
+        "fraction of the window peak, so receiver noise between bursts doesn't "
+        "blow out the y-axis. 0 disables."));
+    layout->addRow(new QLabel(tr("FM squelch:")), fmSquelchSpinBox);
+    connect(fmSquelchSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &SpectrogramControls::fmSquelchChanged);
 
     // Auto-tune button: ask PlotView to pick reasonable values for cutoff,
     // predemod M, and post N. PlotView computes from current Fs and tuner

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -341,6 +341,21 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
         }
     });
 
+    // Signal-strength gate for the FSK polar constellation: only samples whose
+    // differential magnitude exceeds this % of the window peak are plotted, so
+    // noise/dead-air between bursts stays off the scope.
+    constellationGateSpinBox = new QSpinBox(widget);
+    constellationGateSpinBox->setRange(0, 100);
+    constellationGateSpinBox->setValue(15);
+    constellationGateSpinBox->setSuffix("%");
+    constellationGateSpinBox->setToolTip(tr(
+        "Drop samples below this fraction of the window's peak level from the "
+        "FSK polar plot, so only strong (in-burst) parts form the constellation. "
+        "0 disables the gate."));
+    layout->addRow(new QLabel(tr("Constellation min level:")), constellationGateSpinBox);
+    connect(constellationGateSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &SpectrogramControls::constellationGateChanged);
+
     widget->setLayout(layout);
     setWidget(widget);
 

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -308,6 +308,39 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     connect(fmAutoLpfButton, &QPushButton::clicked,
             this, &SpectrogramControls::autoLpfRequested);
 
+    // Symbol rate (baud) for the FSK polar plot's differential delay. The
+    // delay is round(Fs / baud) ≈ one symbol period — the delay at which a
+    // differential constellation collapses to clusters. 0 = unset (the polar
+    // plot hides the scatter and prompts instead of drawing a meaningless
+    // smear). Decoupled from the FM LPF cutoff on purpose.
+    symbolRateLineEdit = new QLineEdit(widget);
+    auto symbolRateValidator = new QDoubleValidator(0.0, 1e9, 3, this);
+    symbolRateLineEdit->setValidator(symbolRateValidator);
+    symbolRateLineEdit->setText("0");
+    symbolRateLineEdit->setToolTip(tr(
+        "Symbol rate (baud) for the FSK polar plot. Sets the differential "
+        "delay to one symbol period; 0 hides the constellation."));
+    layout->addRow(new QLabel(tr("Symbol rate (Bd):")), symbolRateLineEdit);
+    connect(symbolRateLineEdit, &QLineEdit::editingFinished, this, [this]() {
+        bool ok;
+        double baud = symbolRateLineEdit->text().toDouble(&ok);
+        if (ok) emit symbolRateChanged(baud);
+    });
+    // Copy the baud measured by the cursor selection (Symbols ÷ selection
+    // length) into the field and apply it — the manual "estimate" path.
+    useMeasuredBaudButton = new QPushButton(tr("Use measured baud"), widget);
+    useMeasuredBaudButton->setToolTip(tr(
+        "Copy the symbol rate measured by the cursor selection into the field "
+        "above. Set Symbols to the number of symbols spanned, drag the cursors "
+        "across them, then click."));
+    layout->addRow(useMeasuredBaudButton);
+    connect(useMeasuredBaudButton, &QPushButton::clicked, this, [this]() {
+        if (lastMeasuredSymbolRate_ > 0.0) {
+            symbolRateLineEdit->setText(QString::number(lastMeasuredSymbolRate_, 'f', 3));
+            emit symbolRateChanged(lastMeasuredSymbolRate_);
+        }
+    });
+
     widget->setLayout(layout);
     setWidget(widget);
 
@@ -445,6 +478,9 @@ void SpectrogramControls::timeSelectionChanged(float time)
         rateLabel->setText(QString::fromStdString(formatSIValue(1 / time)) + "Hz");
 
         int symbols = cursorSymbolsSpinBox->value();
+        // Remember the raw baud so "Use measured baud" can push it to the FSK
+        // polar plot without re-parsing the SI-formatted label text.
+        lastMeasuredSymbolRate_ = (time > 0.0f) ? (symbols / time) : 0.0;
         symbolPeriodLabel->setText(QString::fromStdString(formatSIValue(time / symbols)) + "s");
         symbolRateLabel->setText(QString::fromStdString(formatSIValue(symbols / time)) + "Bd");
     }

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -60,6 +60,8 @@ signals:
     void symbolRateChanged(double baud);
     // Signal-strength gate (% of window peak) for the FSK polar constellation.
     void constellationGateChanged(int pct);
+    // Symbol-timed (1 point/symbol) vs full-rate FSK polar constellation.
+    void constellationSymbolTimedChanged(bool on);
     // User clicked "Auto-tune FM LPF" — PlotView picks values from the
     // current Fs / tuner bandwidth, applies them, then echoes them back
     // to applyAutoLpf so the dock widgets stay in sync.
@@ -180,6 +182,8 @@ public:
     QPushButton *useMeasuredBaudButton;
     // Signal-strength gate (%) for the FSK polar constellation.
     QSpinBox    *constellationGateSpinBox;
+    // Symbol-timed (1 point/symbol) FSK polar constellation toggle.
+    QCheckBox   *constellationSymbolTimedCheckBox;
     // Save annotations to a .sigmf-meta sidecar. Shown disabled when the
     // annotation list hasn't been mutated since the last load/save.
     QPushButton *saveAnnotationsButton;

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -58,6 +58,8 @@ signals:
     void fmPredemodDecimChanged(int m);
     // Symbol rate (baud) for the FSK polar plot's differential delay. 0 = unset.
     void symbolRateChanged(double baud);
+    // Signal-strength gate (% of window peak) for the FSK polar constellation.
+    void constellationGateChanged(int pct);
     // User clicked "Auto-tune FM LPF" — PlotView picks values from the
     // current Fs / tuner bandwidth, applies them, then echoes them back
     // to applyAutoLpf so the dock widgets stay in sync.
@@ -176,6 +178,8 @@ public:
     // cursor-measured baud into it.
     QLineEdit   *symbolRateLineEdit;
     QPushButton *useMeasuredBaudButton;
+    // Signal-strength gate (%) for the FSK polar constellation.
+    QSpinBox    *constellationGateSpinBox;
     // Save annotations to a .sigmf-meta sidecar. Shown disabled when the
     // annotation list hasn't been mutated since the last load/save.
     QPushButton *saveAnnotationsButton;

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -56,6 +56,8 @@ signals:
     // Pre-demod IQ decimation factor (1 = off). When set the FM demod
     // chain runs at Fs/M (IQEngine pattern).
     void fmPredemodDecimChanged(int m);
+    // Symbol rate (baud) for the FSK polar plot's differential delay. 0 = unset.
+    void symbolRateChanged(double baud);
     // User clicked "Auto-tune FM LPF" — PlotView picks values from the
     // current Fs / tuner bandwidth, applies them, then echoes them back
     // to applyAutoLpf so the dock widgets stay in sync.
@@ -109,6 +111,9 @@ private:
     QFormLayout *layout;
     void clearCursorLabels();
     void fftOrZoomChanged(void);
+    // Last symbol rate (Bd) measured from the cursor selection; copied into
+    // symbolRateLineEdit by the "Use measured baud" button.
+    double lastMeasuredSymbolRate_ = 0.0;
 
 public:
     QPushButton *fileOpenButton;
@@ -167,6 +172,10 @@ public:
     QSpinBox   *fmPredemodDecimSpinBox;
     // Auto-tune button: PlotView picks reasonable values for cutoff, M, N.
     QPushButton *fmAutoLpfButton;
+    // Symbol rate (Bd) for the FSK polar plot, plus a button that copies the
+    // cursor-measured baud into it.
+    QLineEdit   *symbolRateLineEdit;
+    QPushButton *useMeasuredBaudButton;
     // Save annotations to a .sigmf-meta sidecar. Shown disabled when the
     // annotation list hasn't been mutated since the last load/save.
     QPushButton *saveAnnotationsButton;

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -58,6 +58,8 @@ signals:
     void fmPredemodDecimChanged(int m);
     // Symbol rate (baud) for the FSK polar plot's differential delay. 0 = unset.
     void symbolRateChanged(double baud);
+    // Amplitude squelch (% of window-peak |IQ|) for FM plots. 0 = off.
+    void fmSquelchChanged(int pct);
     // Signal-strength gate (% of window peak) for the FSK polar constellation.
     void constellationGateChanged(int pct);
     // Symbol-timed (1 point/symbol) vs full-rate FSK polar constellation.
@@ -174,6 +176,8 @@ public:
     QSpinBox   *fmDecimSpinBox;
     // FM pre-demod IQ decimation (1 disables)
     QSpinBox   *fmPredemodDecimSpinBox;
+    // FM amplitude squelch (% of window-peak |IQ|; 0 disables)
+    QSpinBox   *fmSquelchSpinBox;
     // Auto-tune button: PlotView picks reasonable values for cutoff, M, N.
     QPushButton *fmAutoLpfButton;
     // Symbol rate (Bd) for the FSK polar plot, plus a button that copies the

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -91,6 +91,41 @@ void SpectrogramPlot::paintFront(QPainter &painter, QRect &rect, range_t<size_t>
         paintAnnotations(painter, rect, sampleRange);
 }
 
+static QString formatFrequencyLabel(double hz, bool signedBaseband)
+{
+    const double absHz = fabs(hz);
+    double value = hz;
+    QString unit = QStringLiteral("Hz");
+    int precision = 0;
+
+    if (absHz >= 1000000000.0) {
+        value = hz / 1000000000.0;
+        unit = QStringLiteral("GHz");
+        precision = 6;
+    } else if (absHz >= 1000000.0) {
+        value = hz / 1000000.0;
+        unit = QStringLiteral("MHz");
+        precision = 6;
+    } else if (absHz >= 1000.0) {
+        value = hz / 1000.0;
+        unit = QStringLiteral("kHz");
+        precision = 3;
+    }
+
+    QString number = QString::number(value, 'f', precision);
+    if (precision > 0) {
+        while (number.endsWith('0'))
+            number.chop(1);
+        if (number.endsWith('.'))
+            number.chop(1);
+    }
+
+    if (signedBaseband && hz > 0.0)
+        number.prepend(' ');
+
+    return number + QStringLiteral(" ") + unit;
+}
+
 void SpectrogramPlot::paintFrequencyScale(QPainter &painter, QRect &rect)
 {
     if (sampleRate == 0) {
@@ -101,7 +136,6 @@ void SpectrogramPlot::paintFrequencyScale(QPainter &painter, QRect &rect)
         return;
     }
 
-    // At which pixel is F_+sampleRate/2
     int y = rect.y();
 
     int plotHeight = rect.height();
@@ -121,8 +155,9 @@ void SpectrogramPlot::paintFrequencyScale(QPainter &painter, QRect &rect)
 
     QPen pen(Qt::white, 1, Qt::SolidLine);
     painter.setPen(pen);
-    QFontMetrics fm(painter.font());
 
+    const double centreFrequency = inputSource->getFrequency();
+    const bool showAbsoluteFrequency = centreFrequency != 0.0;
 
     uint64_t tick = 0;
 
@@ -136,23 +171,13 @@ void SpectrogramPlot::paintFrequencyScale(QPainter &painter, QRect &rect)
         painter.drawLine(0, tickpy, 30, tickpy);
 
         if (tick != 0) {
-            char buf[128];
-
-            if (bwPerTick % 1000000000 == 0) {
-                snprintf(buf, sizeof(buf), "-%lu GHz", tick / 1000000000);
-            } else if (bwPerTick % 1000000 == 0) {
-                snprintf(buf, sizeof(buf), "-%lu MHz", tick / 1000000);
-            } else if(bwPerTick % 1000 == 0) {
-                snprintf(buf, sizeof(buf), "-%lu kHz", tick / 1000);
-            } else {
-                snprintf(buf, sizeof(buf), "-%lu Hz", tick);
-            }
+            const double upperHz = showAbsoluteFrequency ? centreFrequency + tick : (double)tick;
+            const double lowerHz = showAbsoluteFrequency ? centreFrequency - tick : -(double)tick;
 
             if (!inputSource->realSignal())
-                painter.drawText(5, tickny - 5, buf);
+                painter.drawText(5, tickny - 5, formatFrequencyLabel(lowerHz, !showAbsoluteFrequency));
 
-            buf[0] = ' ';
-            painter.drawText(5, tickpy + 15, buf);
+            painter.drawText(5, tickpy + 15, formatFrequencyLabel(upperHz, !showAbsoluteFrequency));
         }
 
         tick += bwPerTick;

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -645,7 +645,10 @@ static QImage renderFloatTrace(SampleSource<float> *src,
     const size_t decim = (len > size_t(w)) ? (len + w - 1) / w : 1;
     auto addPoint = [&](size_t i, double xCoord) {
         double s = samples[i];
-        if (!std::isfinite(s)) return;
+        // Break the path at a non-finite sample (squelch / cold-start gap) so
+        // the next finite point starts a fresh subpath instead of bridging the
+        // gap with a straight line.
+        if (!std::isfinite(s)) { first = true; return; }
         double norm = (s - mid) * invRange;
         if (norm >  1.0) norm =  1.0;
         if (norm < -1.0) norm = -1.0;

--- a/src/tunertransform.cpp
+++ b/src/tunertransform.cpp
@@ -20,7 +20,9 @@
 #include "tunertransform.h"
 #include <liquid/liquid.h>
 #include <QMutexLocker>
+#include <algorithm>
 #include <cmath>
+#include <cstring>
 #include "util.h"
 
 TunerTransform::TunerTransform(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src), frequency(0), bandwidth(1.), taps{1.0f}
@@ -34,9 +36,9 @@ void TunerTransform::work(void *input, void *output, int count, size_t sampleid)
     auto temp = std::make_unique<std::complex<float>[]>(count);
 
     // Snapshot parameters under the short-hold paramMutex_ and drop it
-    // before the heavy NCO+FIR loop. The base class's `mutex` is also held
-    // here (by SampleBuffer::getSamples), but the GUI-thread setters use
-    // paramMutex_ instead, so they aren't blocked by this work() running.
+    // before the heavy NCO+FIR loop. The base class's `mutex` is not held
+    // here (getSamples is overridden), and the GUI-thread setters use
+    // paramMutex_, so they aren't blocked by this work() running.
     float freqLocal;
     std::vector<float> tapsLocal;
     {
@@ -68,13 +70,22 @@ void TunerTransform::work(void *input, void *output, int count, size_t sampleid)
 void TunerTransform::setFrequency(float frequency)
 {
     QMutexLocker ml(&paramMutex_);
+    if (this->frequency == frequency)
+        return;
     this->frequency = frequency;
+    // Self-invalidate the block cache so we don't depend on the caller pairing
+    // every setter with notifyChanged(). bumpEpoch() is a non-blocking atomic
+    // and never touches cacheMutex_; cacheMutex_ and paramMutex_ are never held
+    // simultaneously anywhere (getSamples computes blocks OUTSIDE cacheMutex_),
+    // so there is no deadlock.
+    bumpEpoch();
 }
 
 void TunerTransform::setTaps(std::vector<float> taps)
 {
     QMutexLocker ml(&paramMutex_);
     this->taps = std::move(taps);
+    bumpEpoch();
 }
 
 float TunerTransform::relativeBandwidth() {
@@ -84,6 +95,9 @@ float TunerTransform::relativeBandwidth() {
 
 void TunerTransform::setRelativeBandwith(float bandwidth)
 {
+    // Bandwidth never enters the mix/FIR in work() — it's only reported via
+    // relativeBandwidth() — so it does NOT invalidate the tuned-IQ cache.
+    // (A future resampler in work() would have to change this.)
     QMutexLocker ml(&paramMutex_);
     this->bandwidth = bandwidth;
 }
@@ -94,3 +108,146 @@ size_t TunerTransform::historySize()
     return std::max(static_cast<size_t>(256), taps.size());
 }
 
+void TunerTransform::bumpEpoch()
+{
+    cacheEpoch_.fetch_add(1, std::memory_order_release);
+}
+
+void TunerTransform::invalidateEvent()
+{
+    // Upstream changed (new file, etc.): drop the cached blocks. Bump the epoch
+    // BEFORE forwarding so any re-request the fan-out triggers already sees the
+    // advanced epoch and refills.
+    bumpEpoch();
+    SampleBuffer::invalidateEvent();
+}
+
+bool TunerTransform::computeInto(size_t start, size_t length, std::complex<float> *out)
+{
+    // Mirror SampleBuffer::getSamples but lock-free: pull a FIR-history lead-in
+    // on the LEFT (clamped at the file start) so the fresh-FIR cold-start
+    // transient lives in the discarded lead-in, and pass the absolute index of
+    // the first PULLED sample as sampleid so the NCO phase is correct.
+    const size_t history = std::min(start, this->historySize());
+    auto raw = src->getSamples(start - history, length + history);
+    if (!raw)
+        return false;
+    auto temp = std::make_unique<std::complex<float>[]>(length + history);
+    work(raw.get(), temp.get(), static_cast<int>(length + history), start - history);
+    std::memcpy(out, temp.get() + history, length * sizeof(std::complex<float>));
+    return true;
+}
+
+std::unique_ptr<std::complex<float>[]> TunerTransform::computeRange(size_t start, size_t length)
+{
+    auto out = std::make_unique<std::complex<float>[]>(length);
+    if (!computeInto(start, length, out.get()))
+        return nullptr;
+    return out;
+}
+
+TunerTransform::Block TunerTransform::computeBlock(size_t blockIdx)
+{
+    const size_t total = count();
+    const size_t blkStart = blockIdx * kBlock;
+    if (blkStart >= total)
+        return nullptr;
+    const size_t blkLen = std::min(kBlock, total - blkStart);
+    auto vec = std::make_shared<std::vector<std::complex<float>>>(blkLen);
+    if (!computeInto(blkStart, blkLen, vec->data()))
+        return nullptr;
+    return vec;
+}
+
+void TunerTransform::touchLocked(size_t blockIdx)
+{
+    lru_.remove(blockIdx);     // n <= kMaxBlocks, so O(n) is cheap
+    lru_.push_front(blockIdx);
+}
+
+std::unique_ptr<std::complex<float>[]> TunerTransform::getSamples(size_t start, size_t length)
+{
+    if (length == 0)
+        return std::make_unique<std::complex<float>[]>(0);
+    const size_t total = count();
+    if (start >= total || length > total - start)
+        return nullptr; // out of range — match the upstream contract
+
+    const size_t b0 = start / kBlock;
+    const size_t b1 = (start + length - 1) / kBlock;
+
+    // Large requests bypass the cache: they'd evict everyone else's blocks and
+    // thrash a bounded LRU. Compute directly in one pass, exactly like the
+    // pre-cache path (and like FrequencyDemod's own large batch pull).
+    if (b1 - b0 + 1 > kBypassBlocks)
+        return computeRange(start, length);
+
+    const uint64_t nowEpoch = cacheEpoch_.load(std::memory_order_acquire);
+    auto result = std::make_unique<std::complex<float>[]>(length);
+
+    for (size_t b = b0; b <= b1; ++b) {
+        Block blk;
+        bool stale = false;
+        {
+            QMutexLocker lk(&cacheMutex_);
+            // Only an OLDER map gets dropped. mapEpoch_ never exceeds the live
+            // cacheEpoch_, so mapEpoch_ > nowEpoch means a newer generation
+            // already owns the map and *we* are a stale worker draining an old
+            // frame — don't clear it (that would ping-pong against the live
+            // workers and zero the hit rate); just compute directly.
+            if (mapEpoch_ < nowEpoch) {
+                blocks_.clear();
+                lru_.clear();
+                mapEpoch_ = nowEpoch;
+            }
+            if (mapEpoch_ == nowEpoch) {
+                auto it = blocks_.find(b);
+                if (it != blocks_.end()) {
+                    blk = it->second;
+                    touchLocked(b);
+                }
+            } else {
+                stale = true;
+            }
+        }
+        if (!blk) {
+            // Miss (or stale): compute OUTSIDE the lock (work() is reentrant).
+            blk = computeBlock(b);
+            if (!blk)
+                return nullptr;
+            if (!stale) {
+                QMutexLocker lk(&cacheMutex_);
+                // Insert only while we're genuinely current — no epoch bump
+                // since entry AND the map is still our generation. Otherwise a
+                // repaint under the new generation will supersede this frame.
+                if (cacheEpoch_.load(std::memory_order_acquire) == nowEpoch &&
+                    mapEpoch_ == nowEpoch) {
+                    auto it = blocks_.find(b);
+                    if (it == blocks_.end()) {
+                        blocks_.emplace(b, blk);
+                        lru_.push_front(b);
+                        while (lru_.size() > kMaxBlocks) {
+                            blocks_.erase(lru_.back());
+                            lru_.pop_back();
+                        }
+                    } else {
+                        blk = it->second; // someone else computed it first; share theirs
+                        touchLocked(b);
+                    }
+                }
+            }
+        }
+
+        // Copy this block's overlap with [start, start+length) into the result.
+        const size_t blkStart = b * kBlock;
+        const size_t blkEnd = blkStart + blk->size();
+        const size_t copyStart = std::max(start, blkStart);
+        const size_t copyEnd = std::min(start + length, blkEnd);
+        if (copyEnd > copyStart) {
+            std::memcpy(result.get() + (copyStart - start),
+                        blk->data() + (copyStart - blkStart),
+                        (copyEnd - copyStart) * sizeof(std::complex<float>));
+        }
+    }
+    return result;
+}

--- a/src/tunertransform.h
+++ b/src/tunertransform.h
@@ -21,6 +21,11 @@
 
 #include "samplebuffer.h"
 #include <QMutex>
+#include <atomic>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <unordered_map>
 #include <vector>
 
 class TunerTransform : public SampleBuffer<std::complex<float>, std::complex<float>>
@@ -43,11 +48,11 @@ public:
     TunerTransform(std::shared_ptr<SampleSource<std::complex<float>>> src);
     void work(void *input, void *output, int count, size_t sampleid) override;
     // work() uses only local NCO/FIR objects + a paramMutex_ snapshot, so it's
-    // reentrant — run it lock-free so every derived plot's tile workers can
-    // mix+filter the shared tuner output concurrently rather than single-file.
-    // Safety relies on liquid-dsp keeping all nco/firfilt/dotprod state
-    // per-object (true through >= v1.3.2); revisit if a liquid upgrade adds a
-    // shared design cache on the create paths.
+    // reentrant. getSamples() below is overridden (block cache), so the base
+    // SampleBuffer path is never taken — but the block fills call work() lock-free
+    // and in parallel, so this reentrancy is load-bearing. Safety relies on
+    // liquid-dsp keeping all nco/firfilt/dotprod state per-object (true through
+    // >= v1.3.2); revisit if a liquid upgrade adds a shared design cache.
     bool workIsReentrant() override { return true; }
     void setFrequency(float frequency);
     void setTaps(std::vector<float> taps);
@@ -55,10 +60,44 @@ public:
     float relativeBandwidth() override;
     // Notify subscribers (downstream demods, which cascade to their plots)
     // that the mix frequency / filter / bandwidth have changed and any
-    // cached data is stale. Called once after a batch of setters.
+    // cached data is stale. Called once after a batch of setters. (The block
+    // cache is self-invalidating — see the setters — so this is purely the
+    // downstream fan-out now.)
     void notifyChanged() { invalidate(); }
     // The FIR is rebuilt from zero state each call, so the lead-in must cover
     // at least the tap count or the first output samples will be attenuated
     // filter transient — visible as noise in downstream demods.
     size_t historySize() override;
+
+    // Shared block cache of tuned IQ. Every derived plot pulls the tuned output
+    // through this one TunerTransform; without a cache each re-runs the NCO mix
+    // + FIR over its range, redundantly and on every frame. getSamples() serves
+    // BLK-aligned absolute blocks: a hit is a memcpy under a short lock; a miss
+    // computes the block lock-free (work() is reentrant) and inserts it. So
+    // disjoint consumers fill different blocks in parallel and overlapping ones
+    // (and pans) share warm blocks. Invalidated by bumping cacheEpoch_ (atomic,
+    // non-blocking); the map is lazily dropped when its epoch goes stale.
+    std::unique_ptr<std::complex<float>[]> getSamples(size_t start, size_t length) override;
+    void invalidateEvent() override;
+
+private:
+    using Block = std::shared_ptr<const std::vector<std::complex<float>>>;
+    static constexpr size_t kBlock = 65536;       // samples per cache block
+    static constexpr size_t kMaxBlocks = 128;     // ~8.4M samples / ~64 MB cap
+    static constexpr size_t kBypassBlocks = 96;   // larger requests skip the cache
+
+    QMutex                cacheMutex_;             // guards blocks_/lru_/mapEpoch_ only
+    std::atomic<uint64_t> cacheEpoch_{1};
+    uint64_t              mapEpoch_ = 0;           // epoch the current map belongs to
+    std::unordered_map<size_t, Block> blocks_;     // blockIndex -> data
+    std::list<size_t>     lru_;                     // front = most-recently-used
+
+    void bumpEpoch();
+    // Pull upstream IQ with a FIR-history lead-in and run work() into `out`;
+    // [start, start+length). Lock-free (work() reentrant). Returns false on a
+    // null upstream read (out-of-range).
+    bool computeInto(size_t start, size_t length, std::complex<float> *out);
+    std::unique_ptr<std::complex<float>[]> computeRange(size_t start, size_t length);
+    Block computeBlock(size_t blockIdx);
+    void touchLocked(size_t blockIdx);             // assumes cacheMutex_ held
 };

--- a/src/tunertransform.h
+++ b/src/tunertransform.h
@@ -42,6 +42,13 @@ private:
 public:
     TunerTransform(std::shared_ptr<SampleSource<std::complex<float>>> src);
     void work(void *input, void *output, int count, size_t sampleid) override;
+    // work() uses only local NCO/FIR objects + a paramMutex_ snapshot, so it's
+    // reentrant — run it lock-free so every derived plot's tile workers can
+    // mix+filter the shared tuner output concurrently rather than single-file.
+    // Safety relies on liquid-dsp keeping all nco/firfilt/dotprod state
+    // per-object (true through >= v1.3.2); revisit if a liquid upgrade adds a
+    // shared design cache on the create paths.
+    bool workIsReentrant() override { return true; }
     void setFrequency(float frequency);
     void setTaps(std::vector<float> taps);
     void setRelativeBandwith(float bandwidth);


### PR DESCRIPTION
## Summary

Turns the draft FSK components into reliable, signal-agnostic tools for analysing FSK and TETRA (π/4-DQPSK), plus several robustness fixes surfaced along the way. **No TETRA-specific code** — just the generic components needed to understand these signals (differential constellation, normalized-FM eye, value histogram, a shared symbol-rate control), layered on the existing AM/FM/IQ derived plots.

Grounded against the real captures in `/storage/sdr_data/ra14xx` (R&S FSW `ci16` @ 15.36 Msps / 390 MHz; IQEngine `cf32` archives).

## What's in here

**New / reworked tooling**

- **Symbol rate (Bd) control** (SpectrogramControls → PlotView → FskPolarPlot). The FSK polar plot's differential delay is now `round(Fs / baud)` — one symbol period, the only delay at which a differential constellation forms clusters. A *Use measured baud* button copies the cursor-measured baud (Symbols ÷ selection length) into it. Replaces the previous hack of stealing the FM-LPF-cutoff knob (which only worked at one magic cutoff and reshaped the FM trace as a side effect).
- **FSK polar plot rework.** Renders off the GUI thread (`QtConcurrent` + `QFutureWatcher`, mirroring `TracePlot`) as a log-scaled per-pixel **density heatmap**, so symbol-centre phases glow over inter-symbol transition smear. Faint 45° orientation ticks (π/4-DQPSK clusters land on the diagonals). Hints instead of drawing a meaningless ring when the symbol rate is unset or too low for the window.
- **Value histogram plot** (new, registered for any `float` source). The number of peaks reads off the modulation order *clock-free*: 2-FSK → two lobes, 4-FSK → four, GFSK smears them, PSK/noise is unimodal. Off-thread, selection-aware.
- **FskDemod ("FSK eye").** Warmed the AGC cascade (`historySize` 1024 → 1280, removing a window-position artifact) and added a window-relative squelch so dead air between bursts is no longer amplified to full scale.

**Robustness fixes (independent drive-bys, in their own commit)**

- `parseTar()` is now bounded against the mmap — a truncated/hostile `.tar` could carry a size field running past the mapping and read off it (SIGSEGV/SIGBUS). The new `.tar` SigMF suffix widened this path's reach, so it matters more.
- A plain non-SigMF `.tar` falls back to opening as raw IQ instead of throwing.
- `InputSource::frequency` and `_realSignal` are reset per `openFile()` — a baseband/complex file opened after a frequency-tagged/real one inherited stale state and mislabelled the absolute-frequency axis / drew a single-sided spectrogram. gqrx filename-derived centers are applied after `openFile()` so the reset doesn't clobber them.

## How it was reviewed

The starting draft was put through an adversarial multi-agent review (every finding independently re-verified); 27/30 findings held and the improvements above address the confirmed ones. The finished diff was then re-reviewed the same way — that caught a silent delay clamp at 8192 samples (mislabelled off-nominal low-baud/high-Fs cases as "1 symbol"), a squelch pan-dependence, and the `_realSignal` reset gap, all fixed in the final commit.

## Testing

- Builds clean (Release, Qt5).
- Headless smoke tests (`QT_QPA_PLATFORM=offscreen`) open without crashing across every input path: `ci16` `.sigmf.zst` (TETRA @ 15.36 Msps), `cf32` `.tar.zst`, raw `.cf32`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
