### PR TITLE
plugins: external-process analysis API that writes SigMF annotations

### DIFF
--- a/doc/plugin-api-plan.md
+++ b/doc/plugin-api-plan.md
@@ -146,10 +146,11 @@ one `PlotView::runPlugin(const PluginManifest&)`:
   `!cursorsEnabled`; mirrors the export dialog's three-way pattern at
   `plotview.cpp:1417-1427`), then the auto-generated param dialog if the manifest
   declares `params`.
-- Async run via **`QProcess`** (already async — no `QtConcurrent` needed) with a
-  busy `QProgressDialog` + **Cancel** (kills the process) and a timeout `QTimer`;
-  a single-flight guard refuses overlapping runs. Segment extraction is on the GUI
-  thread (bounded by the scope; size-warned) — the slow part is the plugin itself.
+- Async run: segment extraction runs on a **`QtConcurrent`** worker (with a
+  `QFutureWatcher` + an atomic cancel flag), and the **`QProcess`** it feeds is itself
+  async, so the GUI event loop stays live throughout — the busy `QProgressDialog` +
+  **Cancel** aborts both the extraction and the process, backed by a timeout `QTimer`.
+  A single-flight guard refuses overlapping runs; large scopes are size-warned.
 - Returned annotations are added via the existing `addAnnotation()` path, so they are
   immediately editable (drag handles), dirty-tracked, and savable to SigMF / archive.
   Default box colour for auto-detected annotations is a distinct cyan so they read as

--- a/doc/plugin-api-plan.md
+++ b/doc/plugin-api-plan.md
@@ -1,0 +1,208 @@
+# Plugin API — implementation plan
+
+Status: **planning** (not yet implemented). Target branch: `main` (fork `ncasaril/inspectrum`).
+
+## Goal
+
+Let inspectrum hand a **filtered/tuned section** of a recording to an **external
+process**, which analyses it and returns **annotations** (e.g. TETRA calls, sync
+bursts, energy segments). The user reviews the returned annotations in the normal
+annotation UI and saves them back to SigMF like any hand-drawn annotation.
+
+The plugin runs over the same signal the derived plots see — the `TunerTransform`
+output (mixed to baseband, FIR band-pass applied) — **not** the raw wideband file.
+
+## Decisions (locked)
+
+| Question | Decision |
+|----------|----------|
+| Region the plugin runs over | **Offer at run time**: cursor-selection / current-view / whole tuned output |
+| Sample handoff | **Temp SigMF file** (`cf32_le` `.sigmf-data` + `.sigmf-meta`) in the session tmp dir, deleted after |
+| Annotation output schema | **IQEngine-compatible JSON** (SigMF annotation keys), segment-local sample indices |
+
+## Data flow
+
+```
+InputSource ─► TunerTransform (mix to baseband + FIR band-pass)   ← "the filtered section"
+                     │
+            choose window: selection | view | whole
+                     │
+            extract [segStart, segCount] of TunerTransform output
+                     │
+            write seg.sigmf-data (cf32_le) + seg.sigmf-meta (tmp)
+                     │
+   QProcess:  plugin <seg.sigmf-meta>  < context.json  > annotations.json
+                     │
+            parse IQEngine annotations (segment-local indices)
+                     │
+            map segment coords ─► original-file coords
+                     │
+            inputSrc->addAnnotation() × N   → user reviews / edits / saves
+```
+
+## Wire contract
+
+### Manifest — `~/.config/inspectrum/plugins/*.json`
+```json
+{
+  "name": "TETRA burst detector",
+  "exec": "/usr/local/bin/inspectrum-tetra",
+  "args": ["--mode", "calls"],
+  "sample_type": "cf32",
+  "params": [
+    { "key": "threshold_db", "type": "float", "default": -30, "label": "Threshold (dB)" }
+  ]
+}
+```
+- Discovered at startup; each manifest becomes an entry under **Tools → Run plugin ▸**
+  and a context-menu item.
+- `params` auto-generates a small modal dialog (float / int / bool / string / enum).
+- `sample_type` gates which plugins are offered (only `cf32` for now; the tuned
+  output is always complex).
+- Invalid / unreadable manifests are skipped with a logged warning, never fatal.
+
+### Invocation
+```
+<exec> [args...] <seg.sigmf-meta>     stdin = context.json     stdout = annotations.json
+```
+
+`context.json` (IQEngine field names):
+```json
+{
+  "sample_rate": 384000,
+  "center_freq": 391012500,
+  "custom_params": { "threshold_db": -30 }
+}
+```
+
+stdout response (IQEngine annotation shape; **sample indices relative to the segment**):
+```json
+{ "annotations": [
+  { "core:sample_start": 12000, "core:sample_count": 4096,
+    "core:freq_lower_edge": 391000000, "core:freq_upper_edge": 391025000,
+    "core:label": "call", "core:comment": "voice burst" }
+]}
+```
+- `core:sample_start` + `core:sample_count` are **required** on each annotation
+  (IQEngine validates them). `core:freq_lower_edge`/`core:freq_upper_edge` are optional
+  but SigMF requires **both or neither** — inspectrum fills both from the live tuner
+  pass-band when omitted. IQEngine annotations carry `core:label`/`core:comment` (plus
+  `core:generator`/`core:uuid`) and have **no `core:description`** — inspectrum maps
+  `core:label→label`, `core:comment→comment`, and also accepts a non-canonical
+  `core:description` if a plugin emits one (`extra=allow` lets it pass through).
+- This is the IQEngine *annotation schema carried over a CLI*, **not** the
+  IQEngine HTTP service API. A plugin can share its detection core with a real
+  IQEngine plugin — that portability is the reason for the schema choice.
+- Anything the plugin writes to **stderr** is captured and surfaced in an error
+  dialog. Non-zero exit ⇒ no annotations added, error shown.
+
+## Coordinate mapping (RESOLVED — no longer the risky bit)
+
+Both unknowns the original draft flagged are now settled by reading the live code:
+
+- **`TunerTransform` is strictly 1:1** — `work()` mixes (NCO) then FIR-filters in
+  place, the loop emits exactly `count` outputs per `count` inputs, and `count()`/
+  `rate()` are inherited unchanged from `SampleBuffer` (proof:
+  `tunertransform.cpp:50-67,131-138`; a `// A future resampler … would have to change
+  this` comment confirms none exists). **So `orig_sample = segStart + local_sample`,
+  with no `*M` factor.** The segment we extract is the tuned/filtered IQ at full `Fs`,
+  mixed so the tuner band sits at DC.
+- **`Annotation::frequencyRange` is ABSOLUTE Hz** (load stores `core:freq_lower/upper
+  _edge` verbatim, centre is subtracted only at paint time —
+  `inputsource.cpp:541-543`, `spectrogramplot.cpp:310-313`). `sampleRange` is an
+  **absolute, inclusive `[min,max]`** sample index; on disk `core:sample_count =
+  max-min+1` (`inputsource.cpp:1001-1014`).
+
+Resulting maps applied to each returned annotation:
+- Time: `absStart = segStart + core:sample_start`; `sampleRange = {absStart,
+  absStart + core:sample_count - 1}` (inclusive).
+- Frequency: segment meta `captures[0].core:frequency = inputFreq + tunerOffsetHz()`
+  (absolute tuned centre). The plugin emits **absolute** `freq_lower/upper_edge`,
+  stored straight into `frequencyRange`. If the plugin **omits** freq edges (allowed —
+  time-only detection), inspectrum fills them from the live **tuner pass-band**
+  (`centre ± 0.5·tunerBandwidthHz()`).
+
+The parse+map is still factored into a free function `parsePluginAnnotations()` and
+**unit-tested by a standalone harness** (segStart offset, inclusive-max, freq
+passthrough, `#RRGGBBAA→#AARRGGBB` colour rotation, pass-band fallback), plus a
+segment round-trip test (`writeSegmentSigmf()` → reopen with `InputSource` → assert
+count/rate/centre).
+
+## UI surface
+
+The app currently has **no menu bar** (all controls live in the `SpectrogramControls`
+dock; file-open is a dock signal). So integration is two-pronged, both routing through
+one `PlotView::runPlugin(const PluginManifest&)`:
+
+- **Primary: right-click context menu** on the spectrogram — a **Run plugin ▸ <name>**
+  submenu added next to the existing "Add annotation here" / "Extract symbols" /
+  "Export samples…" actions (`plotview.cpp` `contextMenuEvent`, ~`:763`). This is where
+  all the scope state already lives (`selectedSamples`, `viewRange`, `tunerOffsetHz()`,
+  `tunerBandwidthHz()`).
+- **Secondary: a `Tools` menu bar** created in `MainWindow` (the first menu in the app,
+  via `menuBar()->addMenu`), with the same per-plugin actions + **Reload plugins**.
+  Rebuilt on each `openFile` (cleared, not appended) at the `dock->setFileInfo` hook.
+- On launch: scope dialog (Selection / View / Whole — Selection disabled when
+  `!cursorsEnabled`; mirrors the export dialog's three-way pattern at
+  `plotview.cpp:1417-1427`), then the auto-generated param dialog if the manifest
+  declares `params`.
+- Async run via **`QProcess`** (already async — no `QtConcurrent` needed) with a
+  busy `QProgressDialog` + **Cancel** (kills the process) and a timeout `QTimer`;
+  a single-flight guard refuses overlapping runs. Segment extraction is on the GUI
+  thread (bounded by the scope; size-warned) — the slow part is the plugin itself.
+- Returned annotations are added via the existing `addAnnotation()` path, so they are
+  immediately editable (drag handles), dirty-tracked, and savable to SigMF / archive.
+  Default box colour for auto-detected annotations is a distinct cyan so they read as
+  machine-generated until the user edits them.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src/plugin.h` / `src/plugin.cpp` | **new** — manifest model + loader, segment extract → temp SigMF writer, `QProcess` runner (async, timeout, stderr→dialog, cancel), response parse + coordinate map |
+| `src/plotview.cpp` / `.h` | scope dialog, menu/context wiring, `addAnnotation()` of mapped results |
+| `src/mainwindow.cpp` | build **Tools → Run plugin** menu from discovered manifests |
+| `src/spectrogramcontrols.*` | (optional) a "Plugins…" affordance / rescan; not required for v1 |
+| `src/CMakeLists.txt` | append `plugin.cpp` to `inspectrum_sources` |
+| `doc/plugins.md` | **new** — manifest + wire-protocol reference for plugin authors |
+| `examples/plugins/energy-detect.py` | **new** — reference plugin (energy-gate call detector) + smoke test |
+
+## Build stages (each committed on `main`)
+
+1. **Handoff + mapping core (headless, tested).**
+   `Plugin` class: extract window from `TunerTransform` output, write temp SigMF
+   segment, run a stub `QProcess`, parse response, map coords. Standalone harness
+   verifies the segment round-trips (sample count, rate, centre) and the inverse
+   coordinate map (incl. decimation) against known inputs. No GUI yet.
+2. **Manifest discovery + menu.**
+   Load `~/.config/inspectrum/plugins/*.json`, build the Tools menu + context entry,
+   param dialog generation.
+3. **Run UX.**
+   Scope dialog, async run with cancel/timeout, stderr error dialog, add returned
+   annotations through `addAnnotation()`.
+4. **Docs + reference plugin.**
+   `doc/plugins.md` and the Python energy-gate detector; end-to-end smoke test
+   (open file → run plugin → annotations appear → save → reopen).
+
+## Edge cases / risks
+
+- **Large selections at full rate.** A wide whole-file selection at `Fs` can produce
+  a big temp file. Mitigate: warn above a size threshold; consider optional
+  extract-time decimation (which then activates the `M` map above).
+- **Plugin never exits / hangs.** Timeout + Cancel both kill the process; partial
+  stdout is discarded.
+- **Malformed plugin output.** Strict JSON parse; on failure, show stderr + a parse
+  error, add nothing.
+- **Annotation count explosion.** A noisy detector could return thousands; cap with a
+  warning ("plugin returned N; add all / cancel?").
+- **Frequency-edge omission.** If the plugin omits freq edges, default the annotation
+  to the tuner pass-band.
+- **Security.** Plugins are arbitrary local executables the user installed — same
+  trust level as any CLI tool they run; no sandboxing in v1. Documented as such.
+
+## Out of scope for v1
+
+- IQEngine HTTP service plugins (remote/containerised) — file-CLI only for now.
+- Sync-word / correlation detection beyond what a plugin author implements
+  themselves (inspectrum just provides the samples + collects annotations).
+- Streaming/incremental results — plugin runs to completion, then we ingest.

--- a/doc/plugin-api-plan.md
+++ b/doc/plugin-api-plan.md
@@ -1,6 +1,7 @@
 # Plugin API — implementation plan
 
-Status: **planning** (not yet implemented). Target branch: `main` (fork `ncasaril/inspectrum`).
+Status: **implemented** (branch `plugin-api`, fork `ncasaril/inspectrum`). This file is
+kept as the design record; the plugin author reference is `doc/plugins.md`.
 
 ## Goal
 
@@ -122,11 +123,12 @@ Resulting maps applied to each returned annotation:
   time-only detection), inspectrum fills them from the live **tuner pass-band**
   (`centre ± 0.5·tunerBandwidthHz()`).
 
-The parse+map is still factored into a free function `parsePluginAnnotations()` and
-**unit-tested by a standalone harness** (segStart offset, inclusive-max, freq
-passthrough, `#RRGGBBAA→#AARRGGBB` colour rotation, pass-band fallback), plus a
-segment round-trip test (`writeSegmentSigmf()` → reopen with `InputSource` → assert
-count/rate/centre).
+The parse+map is factored into a free function `parsePluginAnnotations()` and was
+validated during development with **standalone harnesses** (segStart offset,
+inclusive-max, freq passthrough, `#RRGGBBAA→#AARRGGBB` colour rotation, pass-band
+fallback, out-of-range clamp; plus a `writeSegmentSigmf()` round-trip and a full
+async run through the reference plugin). These are dev-time harnesses — the repo has
+no registered `ctest` tests yet, so they are not part of the tree.
 
 ## UI surface
 

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -93,7 +93,8 @@ inspectrum extracts the chosen region, writes a temporary SigMF segment, and inv
   (relative to sample 0 of the extracted segment). inspectrum maps them to absolute
   file indices: `abs = segStart + core:sample_start`.
 - `core:freq_lower_edge`, `core:freq_upper_edge` — optional, **absolute Hz**. SigMF
-  requires both or neither. If omitted, inspectrum fills both from the tuner pass-band.
+  requires both or neither. If omitted, inspectrum fills both from the tuner pass-band
+  (or, when the tuner is off, the full input band).
 - `core:label`, `core:comment` — optional text (`core:label` <= ~20 chars by SigMF
   convention; `core:comment` is the longer note). Both are shown/editable.
 - `core:description` — optional longer free-form text, mapped to the annotation's
@@ -127,5 +128,5 @@ See `examples/plugins/energy-detect.py` for a complete, ~150-line reference: it 
 the meta path from `argv[-1]` (the last argument, after any fixed `args`),
 `custom_params` from stdin, loads the `cf32` data with
 numpy, energy-gates against the segment peak, and emits one annotation per detected
-burst (omitting freq edges so inspectrum uses the pass-band). Any language works — the
+burst (omitting freq edges so inspectrum uses the pass-band / full input band). Any language works — the
 contract is just argv + stdin + stdout JSON.

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1,0 +1,127 @@
+# inspectrum analysis plugins
+
+inspectrum can hand a **filtered section** of a recording to an **external process**
+that analyses it and returns **annotations** (bursts, calls, sync words, …). The
+returned annotations appear in the normal annotation UI — editable (drag the handles),
+dirty-tracked, and savable back to SigMF (sidecar or tar+zstd archive) like any
+hand-drawn annotation.
+
+The signal handed to a plugin is the **tuned/filtered IQ** the derived plots see (the
+spectrogram's `TunerTransform` output when the tuner is on, otherwise the raw input),
+extracted over the region you choose. It is mixed to baseband — the tuner centre sits
+at 0 Hz — and carried at the file's full sample rate.
+
+## Installing a plugin
+
+Drop a manifest JSON in:
+
+```
+~/.config/inspectrum/plugins/*.json
+```
+
+It then appears under **Tools → Run plugin ▸ <name>** and in the spectrogram's
+right-click **Run plugin ▸** submenu. Use **Tools → Reload plugins** after adding or
+editing a manifest (the right-click menu rediscovers automatically).
+
+Try the bundled reference detector:
+
+```sh
+mkdir -p ~/.config/inspectrum/plugins
+cp examples/plugins/energy-detect.json ~/.config/inspectrum/plugins/
+# edit "exec" in that copy to the absolute path of examples/plugins/energy-detect.py
+chmod +x examples/plugins/energy-detect.py    # needs python3 + numpy
+```
+
+## Manifest format
+
+```json
+{
+  "name": "Energy burst detector",
+  "exec": "/usr/local/bin/inspectrum-energy-detect",
+  "args": ["--mode", "calls"],
+  "sample_type": "cf32",
+  "params": [
+    { "key": "threshold_db", "type": "float", "label": "Threshold (dB)", "default": -10 }
+  ]
+}
+```
+
+| field         | meaning |
+|---------------|---------|
+| `name`        | menu label (required) |
+| `exec`        | executable: absolute path or PATH-resolvable (required) |
+| `args`        | fixed args prepended before the meta-file path (optional) |
+| `sample_type` | accepted input type; only `cf32` is offered today (default `cf32`) |
+| `params`      | parameters surfaced as a dialog before each run (optional) |
+
+Each `params` entry: `key` (the JSON key passed to the plugin), `type` (`float` `int`
+`bool` `string` `enum`), `label` (dialog text, defaults to `key`), `default`, and
+`choices` (string list, for `enum`). For `int`/`float`, optional `min`/`max` set the
+spin-box bounds and `decimals` the float precision — declare them when a value would
+otherwise be clamped or rounded by the default range (±1e9 int, ±1e12 / 6-decimal
+float). Duplicate `key`s are rejected (the later one is dropped with a warning).
+
+## Wire protocol
+
+inspectrum extracts the chosen region, writes a temporary SigMF segment, and invokes:
+
+```
+<exec> [args...] <segment.sigmf-meta>      # stdin = context.json, stdout = annotations.json
+```
+
+- **argv**: the fixed `args`, then the path to a freshly written
+  `segment.sigmf-meta`. Its `segment.sigmf-data` sibling is `cf32_le` (interleaved
+  little-endian float32 I,Q), with `core:sample_rate` and `captures[0].core:frequency`
+  (the absolute tuned centre, Hz) in the meta.
+- **stdin** (`context.json`):
+  ```json
+  { "sample_rate": 384000, "center_freq": 391012500, "custom_params": { "threshold_db": -10 } }
+  ```
+  `custom_params` holds the values entered in the param dialog, keyed by `key`.
+- **stdout** (`annotations.json`):
+  ```json
+  { "annotations": [
+    { "core:sample_start": 12000, "core:sample_count": 4096,
+      "core:freq_lower_edge": 391000000, "core:freq_upper_edge": 391025000,
+      "core:label": "call", "core:comment": "voice burst" }
+  ]}
+  ```
+
+### Annotation fields
+
+- `core:sample_start`, `core:sample_count` — **required**, integers, **segment-local**
+  (relative to sample 0 of the extracted segment). inspectrum maps them to absolute
+  file indices: `abs = segStart + core:sample_start`.
+- `core:freq_lower_edge`, `core:freq_upper_edge` — optional, **absolute Hz**. SigMF
+  requires both or neither. If omitted, inspectrum fills both from the tuner pass-band.
+- `core:label`, `core:comment` — optional text. (`core:label` ≤ ~20 chars by SigMF
+  convention; `core:comment` is the longer note.)
+- `core:generator`, `core:uuid` — optional, passed through.
+- `presentation:color` — optional `"#RRGGBBAA"`; otherwise a default cyan marks the
+  annotation as machine-generated until you edit it.
+
+This is the IQEngine plugin **annotation schema carried over a CLI** — not the IQEngine
+HTTP service API — so a plugin's detection core can be shared with a real IQEngine
+plugin. Unknown extra keys are ignored.
+
+### Errors and lifecycle
+
+- A **non-zero exit** or **crash** ⇒ no annotations added; the plugin's **stderr** is
+  shown in an error dialog.
+- Malformed stdout JSON ⇒ error shown, nothing added. Annotation entries missing
+  `core:sample_start`/`core:sample_count` are skipped (the rest still apply).
+- Runs are **asynchronous** with a busy dialog + **Cancel** (kills the process) and a
+  timeout. Only one plugin runs at a time.
+
+## Security
+
+Plugins are arbitrary local executables **you** install — same trust level as any CLI
+tool you run. There is no sandboxing. Only install manifests pointing at code you trust.
+
+## Writing a plugin
+
+See `examples/plugins/energy-detect.py` for a complete, ~150-line reference: it reads
+the meta path from `argv[1]`, `custom_params` from stdin, loads the `cf32` data with
+numpy, energy-gates against the segment peak, and emits one annotation per detected
+burst (omitting freq edges so inspectrum uses the pass-band). Any language works — the
+contract is just argv + stdin + stdout JSON.

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -124,7 +124,8 @@ tool you run. There is no sandboxing. Only install manifests pointing at code yo
 ## Writing a plugin
 
 See `examples/plugins/energy-detect.py` for a complete, ~150-line reference: it reads
-the meta path from `argv[1]`, `custom_params` from stdin, loads the `cf32` data with
+the meta path from `argv[-1]` (the last argument, after any fixed `args`),
+`custom_params` from stdin, loads the `cf32` data with
 numpy, energy-gates against the segment peak, and emits one annotation per detected
 burst (omitting freq edges so inspectrum uses the pass-band). Any language works — the
 contract is just argv + stdin + stdout JSON.

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -94,9 +94,12 @@ inspectrum extracts the chosen region, writes a temporary SigMF segment, and inv
   file indices: `abs = segStart + core:sample_start`.
 - `core:freq_lower_edge`, `core:freq_upper_edge` — optional, **absolute Hz**. SigMF
   requires both or neither. If omitted, inspectrum fills both from the tuner pass-band.
-- `core:label`, `core:comment` — optional text. (`core:label` ≤ ~20 chars by SigMF
-  convention; `core:comment` is the longer note.)
-- `core:generator`, `core:uuid` — optional, passed through.
+- `core:label`, `core:comment` — optional text (`core:label` <= ~20 chars by SigMF
+  convention; `core:comment` is the longer note). Both are shown/editable.
+- `core:description` — optional longer free-form text, mapped to the annotation's
+  description field (distinct from `core:label`/`core:comment`).
+- `core:generator`, `core:uuid` — optional; accepted but currently ignored (not
+  stored on the annotation, so not re-emitted on save).
 - `presentation:color` — optional `"#RRGGBBAA"`; otherwise a default cyan marks the
   annotation as machine-generated until you edit it.
 

--- a/examples/plugins/energy-detect.json
+++ b/examples/plugins/energy-detect.json
@@ -1,0 +1,12 @@
+{
+  "name": "Energy burst detector",
+  "exec": "/REPLACE/WITH/ABSOLUTE/PATH/TO/inspectrum/examples/plugins/energy-detect.py",
+  "args": [],
+  "sample_type": "cf32",
+  "params": [
+    { "key": "threshold_db",    "type": "float",  "label": "Threshold (dB below peak)", "default": -10, "min": -120, "max": 0, "decimals": 1 },
+    { "key": "min_duration_ms", "type": "float",  "label": "Min duration (ms)",         "default": 1.0, "min": 0, "max": 100000, "decimals": 3 },
+    { "key": "merge_gap_ms",    "type": "float",  "label": "Merge gap (ms)",            "default": 0.5, "min": 0, "max": 100000, "decimals": 3 },
+    { "key": "label",           "type": "string", "label": "Annotation label",          "default": "burst" }
+  ]
+}

--- a/examples/plugins/energy-detect.py
+++ b/examples/plugins/energy-detect.py
@@ -79,7 +79,9 @@ def main():
     if len(sys.argv) < 2:
         sys.stderr.write("usage: energy-detect.py <segment.sigmf-meta>\n")
         return 2
-    meta_path = sys.argv[1]
+    # inspectrum appends the meta path as the LAST argument (after any fixed args),
+    # so read argv[-1] rather than argv[1].
+    meta_path = sys.argv[-1]
 
     # Context (custom params) on stdin; tolerate an empty stdin.
     raw = sys.stdin.read()

--- a/examples/plugins/energy-detect.py
+++ b/examples/plugins/energy-detect.py
@@ -20,7 +20,8 @@
 """Reference inspectrum analysis plugin: energy-gated burst / call detector.
 
 Contract (see doc/plugins.md):
-  argv[1]  : path to the segment's .sigmf-meta  (cf32_le .sigmf-data alongside it)
+  argv[-1] : path to the segment's .sigmf-meta  (last arg, after any fixed args;
+             cf32_le .sigmf-data alongside it)
   stdin    : JSON { "sample_rate", "center_freq", "custom_params": {...} }
   stdout   : JSON { "annotations": [ {core:sample_start, core:sample_count, ...}, ... ] }
 

--- a/examples/plugins/energy-detect.py
+++ b/examples/plugins/energy-detect.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+#
+#  Copyright (C) 2026, Niklas Casaril <niklas@casaril.com>
+#
+#  This file is part of inspectrum.
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""Reference inspectrum analysis plugin: energy-gated burst / call detector.
+
+Contract (see doc/plugins.md):
+  argv[1]  : path to the segment's .sigmf-meta  (cf32_le .sigmf-data alongside it)
+  stdin    : JSON { "sample_rate", "center_freq", "custom_params": {...} }
+  stdout   : JSON { "annotations": [ {core:sample_start, core:sample_count, ...}, ... ] }
+
+Sample indices in the output are SEGMENT-LOCAL (relative to sample 0 of the
+extracted segment); inspectrum maps them back to absolute file indices. We omit
+core:freq_lower_edge/upper_edge so inspectrum fills them from the tuner pass-band.
+
+custom_params:
+  threshold_db   : gate level relative to the segment's peak power (default -10 dB)
+  min_duration_ms: drop detections shorter than this (default 1.0 ms)
+  merge_gap_ms   : merge detections separated by less than this (default 0.5 ms)
+  label          : label applied to each detection (default "burst")
+"""
+
+import json
+import os
+import sys
+
+import numpy as np
+
+
+def load_meta(meta_path):
+    with open(meta_path, "r") as f:
+        meta = json.load(f)
+    g = meta.get("global", {})
+    caps = meta.get("captures", [{}])
+    data_name = g.get("core:dataset")
+    if not data_name:
+        # Fall back to the conventional sibling name.
+        base = os.path.splitext(meta_path)[0]
+        data_name = os.path.basename(base) + ".sigmf-data"
+    data_path = os.path.join(os.path.dirname(meta_path), data_name)
+    sample_rate = float(g.get("core:sample_rate", 0.0))
+    center_freq = float(caps[0].get("core:frequency", 0.0)) if caps else 0.0
+    datatype = g.get("core:datatype", "cf32_le")
+    return data_path, sample_rate, center_freq, datatype
+
+
+def find_runs(mask):
+    """Yield (start, end) half-open index ranges of contiguous True in mask."""
+    if mask.size == 0:
+        return
+    # Edges where the boolean changes.
+    diff = np.diff(mask.astype(np.int8))
+    starts = list(np.where(diff == 1)[0] + 1)
+    ends = list(np.where(diff == -1)[0] + 1)
+    if mask[0]:
+        starts.insert(0, 0)
+    if mask[-1]:
+        ends.append(mask.size)
+    for s, e in zip(starts, ends):
+        yield int(s), int(e)
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.stderr.write("usage: energy-detect.py <segment.sigmf-meta>\n")
+        return 2
+    meta_path = sys.argv[1]
+
+    # Context (custom params) on stdin; tolerate an empty stdin.
+    raw = sys.stdin.read()
+    ctx = json.loads(raw) if raw.strip() else {}
+    params = ctx.get("custom_params", {}) or {}
+
+    threshold_db = float(params.get("threshold_db", -10.0))
+    min_duration_ms = float(params.get("min_duration_ms", 1.0))
+    merge_gap_ms = float(params.get("merge_gap_ms", 0.5))
+    label = str(params.get("label", "burst"))
+
+    data_path, sample_rate, center_freq, datatype = load_meta(meta_path)
+    if datatype != "cf32_le":
+        sys.stderr.write("energy-detect: expected cf32_le, got %s\n" % datatype)
+        return 1
+    # Prefer the rate handed in via context if the meta lacks it.
+    if sample_rate <= 0:
+        sample_rate = float(ctx.get("sample_rate", 0.0))
+
+    # Stream the segment in bounded chunks via memmap rather than loading it whole:
+    # inspectrum can extract multi-GB segments from 100GB+ captures, and float32
+    # power keeps peak RAM to ~one chunk regardless of segment size.
+    nbytes = os.path.getsize(data_path)
+    n_samples = nbytes // 8  # complex64 == 8 bytes
+    if n_samples == 0:
+        print(json.dumps({"annotations": []}))
+        return 0
+    x = np.memmap(data_path, dtype=np.complex64, mode="r", shape=(n_samples,))
+    CHUNK = 1 << 20  # 1 Msample/chunk
+
+    def chunk_power(off):
+        c = x[off:off + CHUNK]
+        return c.real.astype(np.float32) ** 2 + c.imag.astype(np.float32) ** 2
+
+    # Pass 1: global peak power (no whole-segment allocation).
+    peak = 0.0
+    for off in range(0, n_samples, CHUNK):
+        p = chunk_power(off)
+        if p.size:
+            peak = max(peak, float(p.max()))
+    if peak <= 0:
+        print(json.dumps({"annotations": []}))
+        return 0
+
+    thresh = peak * (10.0 ** (threshold_db / 10.0))
+    min_samples = max(1, int(min_duration_ms * 1e-3 * sample_rate)) if sample_rate > 0 else 1
+    merge_samples = int(merge_gap_ms * 1e-3 * sample_rate) if sample_rate > 0 else 0
+
+    # Pass 2: collect above-threshold runs per chunk in absolute indices. A run split
+    # across a chunk boundary has gap 0 and is rejoined by the merge pass below.
+    runs = []
+    for off in range(0, n_samples, CHUNK):
+        mask = chunk_power(off) > thresh
+        for s, e in find_runs(mask):
+            runs.append((off + s, off + e))
+
+    # Merge runs separated by a gap <= merge_samples (also stitches boundary splits).
+    merged = []
+    for s, e in runs:
+        if merged and s - merged[-1][1] <= merge_samples:
+            merged[-1][1] = e
+        else:
+            merged.append([s, e])
+
+    annotations = []
+    for s, e in merged:
+        if (e - s) < min_samples:
+            continue
+        dur_ms = (e - s) / sample_rate * 1e3 if sample_rate > 0 else 0.0
+        annotations.append({
+            "core:sample_start": int(s),
+            "core:sample_count": int(e - s),
+            "core:label": label,
+            "core:comment": "energy-detect: %.2f ms" % dur_ms,
+            "core:generator": "inspectrum energy-detect.py",
+        })
+
+    json.dump({"annotations": annotations}, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ list(APPEND inspectrum_sources
     plot.cpp
     plots.cpp
     plotview.cpp
+    plugin.cpp
     samplebuffer.cpp
     samplesource.cpp
     spectrogramcontrols.cpp

--- a/src/amplitudedemod.cpp
+++ b/src/amplitudedemod.cpp
@@ -18,6 +18,8 @@
  */
 
 #include "amplitudedemod.h"
+#include <algorithm>
+#include <cmath>
 
 AmplitudeDemod::AmplitudeDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src)
 {
@@ -28,6 +30,40 @@ void AmplitudeDemod::work(void *input, void *output, int count, size_t sampleid)
 {
     auto in = static_cast<std::complex<float>*>(input);
     auto out = static_cast<float*>(output);
-    std::transform(in, in + count, out,
-                   [](std::complex<float> s) { return std::norm(s) * 2.0f - 1.0f; });
+
+    // Snapshot the display mode once per call so a mid-flight setter can't
+    // make the tile half-linear / half-dB.
+    const bool db = dbMode_.load(std::memory_order_relaxed);
+    if (!db) {
+        std::transform(in, in + count, out,
+                       [](std::complex<float> s) { return std::norm(s) * 2.0f - 1.0f; });
+        return;
+    }
+
+    // dB scale: 10·log10(|x|²) = 20·log10(|x|), plus the full-scale reference
+    // so the trace reads in dBFS (ref 0) or calibrated dBm (ref set). Silence
+    // (|x| = 0) is floored instead of producing -inf, which would poison the
+    // autoscale and leave a gap in the trace.
+    const float ref = static_cast<float>(refDbm_.load(std::memory_order_relaxed));
+    constexpr float kFloorDb = -120.0f;
+    for (int i = 0; i < count; i++) {
+        const float p = std::norm(in[i]);
+        float dbv = (p > 0.0f) ? 10.0f * std::log10(p) : kFloorDb;
+        if (dbv < kFloorDb) dbv = kFloorDb;
+        out[i] = dbv + ref;
+    }
+}
+
+void AmplitudeDemod::setDbMode(bool on)
+{
+    if (dbMode_.exchange(on, std::memory_order_relaxed) == on)
+        return;
+    invalidate();
+}
+
+void AmplitudeDemod::setReferenceLevelDbm(double dbm)
+{
+    if (refDbm_.exchange(dbm, std::memory_order_relaxed) == dbm)
+        return;
+    invalidate();
 }

--- a/src/amplitudedemod.h
+++ b/src/amplitudedemod.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <atomic>
 #include "samplebuffer.h"
 
 class AmplitudeDemod : public SampleBuffer<std::complex<float>, float>
@@ -26,5 +27,24 @@ class AmplitudeDemod : public SampleBuffer<std::complex<float>, float>
 public:
     AmplitudeDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
     void work(void *input, void *output, int count, size_t sampleid) override;
-    bool workIsReentrant() override { return true; } // stateless |x|² map
+    // work() only reads dbMode_/refDbm_ (snapshotted per call via atomic
+    // loads) and never mutates instance state, so it stays lock-free for
+    // parallel tile workers.
+    bool workIsReentrant() override { return true; }
+
+    // Switch the output between the default linear power (2|x|²-1) and a
+    // logarithmic scale: 10·log10(|x|²) + reference. Invalidates so cached
+    // trace tiles recompute.
+    void setDbMode(bool on);
+    // Reference level (dBm) that maps to full scale (|x| = 1). Added to the
+    // dB output so the plot reads calibrated dBm; 0 leaves it as dBFS.
+    void setReferenceLevelDbm(double dbm);
+    bool dbMode() const { return dbMode_.load(std::memory_order_relaxed); }
+    double referenceLevelDbm() const { return refDbm_.load(std::memory_order_relaxed); }
+
+private:
+    // Lock-free so the reentrant work() can read them without serialising the
+    // tile workers; GUI-thread setters store + invalidate().
+    std::atomic<bool> dbMode_{false};
+    std::atomic<double> refDbm_{0.0};
 };

--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -489,6 +489,11 @@ QJsonObject InputSource::parseMetaDocument(const QByteArray &bytes)
     }
     _datatype = datatype;
 
+    // Editable global metadata. core:description is the standard free-text
+    // note; inspectrum:title is our non-standard short name.
+    _globalDescription = global["core:description"].toString();
+    _globalTitle = global["inspectrum:title"].toString();
+
     if (global.contains("core:sample_rate") && global["core:sample_rate"].isDouble()) {
         setSampleRate(global["core:sample_rate"].toDouble());
     }
@@ -695,7 +700,25 @@ void InputSource::openFile(const char *filename)
     _archiveZstd = false;
     _containerPath.clear();
     _archiveMetaName.clear();
+    _globalDescription.clear();
+    _globalTitle.clear();
     openFileImpl(filename);
+}
+
+void InputSource::setGlobalDescription(const QString &text)
+{
+    if (_globalDescription == text) return;
+    _globalDescription = text;
+    _annotationsDirty = true;
+    for (auto &cb : _annotCbs) if (cb) cb();
+}
+
+void InputSource::setGlobalTitle(const QString &text)
+{
+    if (_globalTitle == text) return;
+    _globalTitle = text;
+    _annotationsDirty = true;
+    for (auto &cb : _annotCbs) if (cb) cb();
 }
 
 void InputSource::openFileImpl(const char *filename)
@@ -1181,6 +1204,18 @@ bool InputSource::saveAnnotations(QString *errorOut)
         root.insert("global", global);
         root.insert("captures", captures);
         root.insert("annotations", annotations);
+    }
+
+    // Fold the editable global metadata into global. Only write non-empty
+    // values so we don't clobber a synthesized description or litter the file
+    // with empty keys.
+    {
+        QJsonObject g = root["global"].toObject();
+        if (!_globalDescription.isEmpty())
+            g.insert("core:description", _globalDescription);
+        if (!_globalTitle.isEmpty())
+            g.insert("inspectrum:title", _globalTitle);
+        root.insert("global", g);
     }
 
     // SigMF archive (tar / tar+zstd): append an updated .sigmf-meta member back

--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -27,6 +27,7 @@
 
 #include <stdexcept>
 #include <algorithm>
+#include <ctime>
 #include <vector>
 
 #include <QFileInfo>
@@ -265,7 +266,12 @@ static std::vector<TarEntry> parseTar(const uchar *data, qint64 totalSize)
         const char *hdr = reinterpret_cast<const char*>(data + pos);
         bool allZero = true;
         for (int i = 0; i < 512; ++i) { if (hdr[i]) { allZero = false; break; } }
-        if (allZero) break;
+        // A zero block is the end-of-archive marker. We DON'T stop here:
+        // inspectrum appends updated .sigmf-meta members as extra tar fragments
+        // past this marker (see appendMetaToArchive), so skip the padding and
+        // keep scanning. A genuinely truncated archive just runs out of blocks
+        // and the loop ends; a bad size field below still bails out.
+        if (allZero) { pos += 512; continue; }
 
         // Name: 100 bytes, null-terminated; use memchr to stay within the field
         const char *nul = static_cast<const char*>(memchr(hdr, 0, 100));
@@ -536,8 +542,12 @@ QJsonObject InputSource::parseMetaDocument(const QByteArray &bytes)
                 auto comment = sigmf_annotation["core:comment"].toString();
 
                 auto sigmf_color = sigmf_annotation["presentation:color"].toString();
-                // SigMF uses the format "#RRGGBBAA" for alpha-channel colors, QT uses "#AARRGGBB"
-                if ((sigmf_color.at(0) == '#') && (sigmf_color.length()) == 9) {
+                // SigMF uses the format "#RRGGBBAA" for alpha-channel colors, QT uses "#AARRGGBB".
+                // Test length first: an annotation may carry no presentation:color (then
+                // toString() is empty), and at(0) on an empty QString is out of bounds —
+                // a latent crash in debug builds / UB in release. && short-circuits so
+                // at(0) only runs once we know there are 9 chars.
+                if ((sigmf_color.length() == 9) && (sigmf_color.at(0) == '#')) {
                     sigmf_color = "#" + sigmf_color.mid(7,2) + sigmf_color.mid(1,6);
                 }
                 auto boxColor = QString::fromStdString("white");
@@ -655,8 +665,20 @@ bool InputSource::openSigmfArchive(const uchar *data, qint64 size)
     QByteArray metaBytes(reinterpret_cast<const char*>(data + metaEntry->dataOffset),
                          static_cast<int>(metaEntry->size));
     // parseMetaDocument picks the sample adapter and sets sampleRate /
-    // frequency / annotations exactly as the .sigmf-* pair path does.
+    // frequency / annotations exactly as the .sigmf-* pair path does. Because
+    // parseTar reads through EOF padding, metaEntry is the LAST .sigmf-meta in
+    // the archive — i.e. the newest appended update wins automatically.
     parseMetaDocument(metaBytes);
+
+    // Remember enough to append an updated meta later: the full parsed root (so
+    // unrelated keys round-trip) and the meta member's name (reused so the
+    // appended member reads as an update of the same file).
+    _isArchive = true;
+    _archiveMetaName = metaEntry->name;
+    QJsonParseError perr;
+    QJsonDocument doc = QJsonDocument::fromJson(metaBytes, &perr);
+    _originalSigmfRoot = (perr.error == QJsonParseError::NoError && doc.isObject())
+                             ? doc.object() : QJsonObject();
 
     dataOffset = static_cast<size_t>(dataEntry->dataOffset);
     sampleCount = dataEntry->size / sampleAdapter->sampleSize();
@@ -664,6 +686,19 @@ bool InputSource::openSigmfArchive(const uchar *data, qint64 size)
 }
 
 void InputSource::openFile(const char *filename)
+{
+    // Reset the SigMF-archive tracking once for the whole open. openFileImpl
+    // recurses for transparent zstd, and an inner frame must be able to see the
+    // _containerPath / _archiveZstd the outer (zstd) frame set — so the reset
+    // lives here, not in openFileImpl.
+    _isArchive = false;
+    _archiveZstd = false;
+    _containerPath.clear();
+    _archiveMetaName.clear();
+    openFileImpl(filename);
+}
+
+void InputSource::openFileImpl(const char *filename)
 {
     QFileInfo fileInfo(filename);
     _filePath = fileInfo.absoluteFilePath();
@@ -693,7 +728,13 @@ void InputSource::openFile(const char *filename)
     // set, since that names the raw layout of `filename` itself.
     if (_fmt.empty() && fileInfo.suffix().compare("zst", Qt::CaseInsensitive) == 0) {
         QString decompressed = decompressZstToCache(fileInfo);
-        openFile(decompressed.toUtf8().constData());
+        // Remember the ORIGINAL compressed container so a later save appends an
+        // updated meta frame here, not beside the decompression-cache temp that
+        // _filePath is about to point at. Recurse via openFileImpl so this
+        // survives (openFile would reset it).
+        _containerPath = fileInfo.absoluteFilePath();
+        _archiveZstd = true;
+        openFileImpl(decompressed.toUtf8().constData());
         return;
     }
 
@@ -831,6 +872,11 @@ void InputSource::openFile(const char *filename)
         }
 
         if (handled) {
+            // For a directly-opened (uncompressed) archive, this file IS the
+            // append target. When we got here via the zstd branch, _containerPath
+            // already points at the .zst and must be left alone.
+            if (_containerPath.isEmpty())
+                _containerPath = fileInfo.absoluteFilePath();
             cleanup();
             inputFile = file.release();
             mmapData = data;
@@ -971,6 +1017,123 @@ bool InputSource::removeAnnotation(int index)
     return true;
 }
 
+// Write a classic ustar numeric field: `len-1` zero-padded octal digits then a
+// NUL terminator. Oversized values keep their least-significant digits (never
+// happens for our small metas, but stays in-bounds if it ever did).
+static void writeTarOctal(char *field, int len, qulonglong val)
+{
+    QByteArray s = QByteArray::number(val, 8);
+    if (s.size() > len - 1)
+        s = s.right(len - 1);
+    s = s.rightJustified(len - 1, '0');
+    memcpy(field, s.constData(), len - 1);
+    field[len - 1] = '\0';
+}
+
+// Build a single ustar tar member (512-byte header + content padded to a
+// 512-byte boundary) for `name` carrying `content`. No EOF blocks — the caller
+// appends those once after the member.
+static QByteArray buildTarMember(const QByteArray &name, const QByteArray &content)
+{
+    QByteArray block(512, '\0');
+    char *h = block.data();
+    int n = std::min(name.size(), 100);
+    memcpy(h, name.constData(), n);
+    writeTarOctal(h + 100, 8, 0644);                                   // mode
+    writeTarOctal(h + 108, 8, 0);                                      // uid
+    writeTarOctal(h + 116, 8, 0);                                      // gid
+    writeTarOctal(h + 124, 12, (qulonglong)content.size());           // size
+    writeTarOctal(h + 136, 12, (qulonglong)time(nullptr));            // mtime
+    memset(h + 148, ' ', 8);                                          // chksum field = spaces while summing
+    h[156] = '0';                                                     // typeflag: regular file
+    memcpy(h + 257, "ustar", 5);                                      // magic (262 stays NUL)
+    h[263] = '0'; h[264] = '0';                                       // version "00"
+    unsigned int sum = 0;
+    for (int i = 0; i < 512; ++i) sum += (unsigned char)h[i];
+    QByteArray cs = QByteArray::number((qulonglong)sum, 8).rightJustified(6, '0');
+    memcpy(h + 148, cs.constData(), 6);
+    h[154] = '\0';
+    h[155] = ' ';
+
+    QByteArray member = block;
+    member.append(content);
+    int pad = (512 - (content.size() % 512)) % 512;
+    if (pad) member.append(QByteArray(pad, '\0'));
+    return member;
+}
+
+bool InputSource::appendMetaToArchive(const QJsonObject &root, QString *errorOut)
+{
+    if (_containerPath.isEmpty()) {
+        if (errorOut) *errorOut = "No archive container path is known for this input.";
+        return false;
+    }
+
+    const QByteArray json = QJsonDocument(root).toJson(QJsonDocument::Indented);
+
+    // Reuse the original meta member name so the appended entry reads as an
+    // update of the same file; fall back to "<base>.sigmf-meta" if unknown or
+    // too long for the 100-byte ustar name field.
+    QByteArray memberName = _archiveMetaName.toUtf8();
+    if (memberName.isEmpty() || memberName.size() > 100) {
+        memberName = QFileInfo(_containerPath).baseName().toUtf8() + ".sigmf-meta";
+        if (memberName.size() > 100)
+            memberName = QByteArrayLiteral("inspectrum.sigmf-meta");
+    }
+
+    // tar fragment: the member followed by the two-block end-of-archive marker,
+    // so the appended bytes are themselves a well-formed archive tail.
+    QByteArray fragment = buildTarMember(memberName, json);
+    fragment.append(QByteArray(1024, '\0'));
+
+    QByteArray payload;
+    if (_archiveZstd) {
+#ifdef HAVE_ZSTD
+        // Compress the fragment as one independent zstd frame and append it.
+        // zstd frames concatenate, so the existing streaming decompressor
+        // inflates [original frames][this frame] as one continuous tar.
+        size_t bound = ZSTD_compressBound((size_t)fragment.size());
+        payload.resize((int)bound);
+        size_t csz = ZSTD_compress(payload.data(), bound,
+                                   fragment.constData(), (size_t)fragment.size(), 19);
+        if (ZSTD_isError(csz)) {
+            if (errorOut) *errorOut = QStringLiteral("zstd compress failed: %1")
+                                          .arg(ZSTD_getErrorName(csz));
+            return false;
+        }
+        payload.resize((int)csz);
+#else
+        if (errorOut) *errorOut = "This build has no zstd support; cannot update a .zst archive.";
+        return false;
+#endif
+    } else {
+        payload = fragment;
+    }
+
+    // Append-only. The original bytes are never modified, so a failed or partial
+    // write is undone by truncating back to the pre-append size.
+    const qint64 origSize = QFileInfo(_containerPath).size();
+    QFile f(_containerPath);
+    if (!f.open(QIODevice::Append)) {
+        if (errorOut) *errorOut = "Could not open " + _containerPath + " for appending: " + f.errorString();
+        return false;
+    }
+    bool ok = (f.write(payload) == (qint64)payload.size()) && f.flush();
+    QString werr = f.errorString();
+    f.close();
+    if (!ok) {
+        QFile::resize(_containerPath, origSize); // discard any partial append
+        if (errorOut) *errorOut = "Append failed (rolled back): " + werr;
+        return false;
+    }
+
+    // The appended member is now the authority; round-trip against it next save.
+    _originalSigmfRoot = root;
+    _annotationsDirty = false;
+    for (auto &cb : _annotCbs) if (cb) cb();
+    return true;
+}
+
 bool InputSource::saveAnnotations(QString *errorOut)
 {
     if (_filePath.isEmpty()) {
@@ -994,7 +1157,7 @@ bool InputSource::saveAnnotations(QString *errorOut)
         annotations.append(annotationToJson(a));
 
     QJsonObject root;
-    if (_wasSigmfInput && !_originalSigmfRoot.isEmpty()) {
+    if ((_wasSigmfInput || _isArchive) && !_originalSigmfRoot.isEmpty()) {
         // Round-trip every other key the original meta had; only annotations
         // gets replaced. This avoids losing custom captures, hardware tags,
         // extension keys, etc.
@@ -1019,6 +1182,13 @@ bool InputSource::saveAnnotations(QString *errorOut)
         root.insert("captures", captures);
         root.insert("annotations", annotations);
     }
+
+    // SigMF archive (tar / tar+zstd): append an updated .sigmf-meta member back
+    // into the container instead of writing a sidecar into the decompression
+    // cache (where _filePath points for a .zst). The newest member wins on the
+    // next open.
+    if (_isArchive)
+        return appendMetaToArchive(root, errorOut);
 
     QFile out(metaPath);
     if (!out.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {

--- a/src/inputsource.h
+++ b/src/inputsource.h
@@ -58,6 +58,11 @@ private:
     QJsonObject _originalSigmfRoot;
     bool _wasSigmfInput = false;
     bool _annotationsDirty = false;
+    // Editable global metadata: SigMF core:description (free-text note for the
+    // whole capture) and a non-standard inspectrum:title. Parsed on open,
+    // written back into global on save. Empty when absent.
+    QString _globalDescription;
+    QString _globalTitle;
     // SigMF-archive (tar / tar+zstd) tracking, so saveAnnotations can append an
     // updated .sigmf-meta member back into the container instead of orphaning a
     // sidecar in the decompression cache. _containerPath is the ORIGINAL file
@@ -136,4 +141,14 @@ public:
     bool saveAnnotations(QString *errorOut = nullptr);
     void addAnnotationCallback(AnnotationCallback cb) { _annotCbs.push_back(std::move(cb)); }
     QString sigmfDatatype() const { return _datatype; }
+
+    // Editable global file metadata. Getters return what was parsed on open
+    // (or last set); setters mark the dirty flag and fire the change callbacks
+    // (so the Save button enables) but don't invalidate the render pipeline —
+    // these are text fields, not signal parameters. Persisted into global on
+    // the next saveAnnotations().
+    QString globalDescription() const { return _globalDescription; }
+    QString globalTitle() const { return _globalTitle; }
+    void setGlobalDescription(const QString &text);
+    void setGlobalTitle(const QString &text);
 };

--- a/src/inputsource.h
+++ b/src/inputsource.h
@@ -58,10 +58,31 @@ private:
     QJsonObject _originalSigmfRoot;
     bool _wasSigmfInput = false;
     bool _annotationsDirty = false;
+    // SigMF-archive (tar / tar+zstd) tracking, so saveAnnotations can append an
+    // updated .sigmf-meta member back into the container instead of orphaning a
+    // sidecar in the decompression cache. _containerPath is the ORIGINAL file
+    // the user opened (the .sigmf.zst / .sigmf / .tar), not the decompressed
+    // temp that _filePath points at. _archiveMetaName is the tar member name of
+    // the meta entry, reused for the appended member so it reads as an update.
+    bool _isArchive = false;
+    bool _archiveZstd = false;
+    QString _containerPath;
+    QString _archiveMetaName;
     using AnnotationCallback = std::function<void()>;
     std::vector<AnnotationCallback> _annotCbs;
 
     QJsonObject readMetaData(const QString &filename);
+    // Body of openFile, separated so the public openFile can reset the
+    // container-tracking state once and then recurse (for transparent zstd)
+    // without that reset clobbering what an outer frame discovered.
+    void openFileImpl(const char *filename);
+    // Append an updated .sigmf-meta to the open SigMF archive: build a tar
+    // member (+ EOF blocks), zstd-compress it as one frame when the container
+    // is compressed, and append it to _containerPath. The original bytes are
+    // never modified — a failed write is rolled back by truncating to the
+    // pre-append size. The newest meta wins on the next open. Returns false and
+    // sets *errorOut on failure.
+    bool appendMetaToArchive(const QJsonObject &root, QString *errorOut);
     // Parse a SigMF meta document (the JSON bytes of a .sigmf-meta) and apply
     // it: pick the sampleAdapter from core:datatype and populate sampleRate /
     // frequency / annotations. Shared by the .sigmf-* pair path and the

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -49,6 +49,11 @@ MainWindow::MainWindow()
 
     connect(dock, &SpectrogramControls::saveAnnotationsRequested,
             this, &MainWindow::saveAnnotations);
+    // Editable global file metadata → InputSource (persisted on save).
+    connect(dock, &SpectrogramControls::fileTitleChanged,
+            this, [this](QString t) { input->setGlobalTitle(t); });
+    connect(dock, &SpectrogramControls::fileDescriptionChanged,
+            this, [this](QString d) { input->setGlobalDescription(d); });
 
     // Connect dock inputs
     connect(dock, &SpectrogramControls::openFile, this, &MainWindow::openFile);
@@ -177,6 +182,9 @@ void MainWindow::openFile(QString fileName)
         if (pendingCenterHz > 0.0) {
             input->setCenterFrequency(pendingCenterHz);
         }
+        // Populate the dock's editable global metadata from the freshly-opened
+        // file (one-shot; setText doesn't re-emit the change signals).
+        dock->setFileInfo(input->globalTitle(), input->globalDescription());
     }
     catch (const std::exception &ex)
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -76,6 +76,9 @@ MainWindow::MainWindow()
     connect(dock, &SpectrogramControls::fmPredemodDecimChanged, plots, &PlotView::setFmPredemodDecimation);
     // FM amplitude squelch (% of window-peak |IQ|).
     connect(dock, &SpectrogramControls::fmSquelchChanged, plots, &PlotView::setFmSquelch);
+    // AM plot dB scale + full-scale reference (dBm; 0 = dBFS).
+    connect(dock, &SpectrogramControls::amDbModeChanged, plots, &PlotView::setAmDbMode);
+    connect(dock, &SpectrogramControls::amRefLevelChanged, plots, &PlotView::setAmReferenceLevel);
     // Symbol rate (Bd) for the FSK polar plot's differential delay.
     connect(dock, &SpectrogramControls::symbolRateChanged, plots, &PlotView::setSymbolRate);
     // Signal-strength gate (%) for the FSK polar constellation.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -47,6 +47,14 @@ MainWindow::MainWindow()
     plots = new PlotView(input);
     setCentralWidget(plots);
 
+    // The app ships no menu bar of its own; create one here to host external
+    // analysis plugins (Tools → Run plugin ▸ <name>). Rebuilt on each open.
+    QMenu *toolsMenu = menuBar()->addMenu(tr("Tools"));
+    pluginMenu = toolsMenu->addMenu(tr("Run plugin"));
+    toolsMenu->addSeparator();
+    toolsMenu->addAction(tr("Reload plugins"), this, &MainWindow::rebuildPluginMenu);
+    rebuildPluginMenu();
+
     connect(dock, &SpectrogramControls::saveAnnotationsRequested,
             this, &MainWindow::saveAnnotations);
     // Editable global file metadata → InputSource (persisted on save).
@@ -191,6 +199,15 @@ void MainWindow::openFile(QString fileName)
         QMessageBox msgBox(QMessageBox::Critical, "Inspectrum openFile error", QString("%1: %2").arg(fileName).arg(ex.what()));
         msgBox.exec();
     }
+}
+
+void MainWindow::rebuildPluginMenu()
+{
+    if (pluginMenu == nullptr)
+        return;
+    pluginMenu->clear();
+    PlotView::buildPluginMenu(pluginMenu,
+                              [this](const PluginManifest &mf) { plots->runPlugin(mf); });
 }
 
 void MainWindow::invalidateEvent()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -48,7 +48,8 @@ MainWindow::MainWindow()
     setCentralWidget(plots);
 
     // The app ships no menu bar of its own; create one here to host external
-    // analysis plugins (Tools → Run plugin ▸ <name>). Rebuilt on each open.
+    // analysis plugins (Tools -> Run plugin -> <name>). Built at startup and
+    // refreshed via "Reload plugins" (the right-click submenu rediscovers on its own).
     QMenu *toolsMenu = menuBar()->addMenu(tr("Tools"));
     pluginMenu = toolsMenu->addMenu(tr("Run plugin"));
     toolsMenu->addSeparator();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -50,8 +50,8 @@ protected:
 private:
     void onAnnotationsChanged();
     void refreshWindowTitle();
-    // (Re)populate the Tools → Run plugin menu from the manifests in
-    // ~/.config/inspectrum/plugins. Called at startup and after each open.
+    // (Re)populate the Tools -> Run plugin menu from the manifests in
+    // ~/.config/inspectrum/plugins. Called at startup and from "Reload plugins".
     void rebuildPluginMenu();
 
     SpectrogramControls *dock;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -24,6 +24,8 @@
 #include "spectrogramcontrols.h"
 #include "plotview.h"
 
+class QMenu;
+
 class MainWindow : public QMainWindow, Subscriber
 {
     Q_OBJECT
@@ -48,10 +50,15 @@ protected:
 private:
     void onAnnotationsChanged();
     void refreshWindowTitle();
+    // (Re)populate the Tools → Run plugin menu from the manifests in
+    // ~/.config/inspectrum/plugins. Called at startup and after each open.
+    void rebuildPluginMenu();
 
     SpectrogramControls *dock;
     PlotView *plots;
     InputSource *input;
+    // The app's only menu — built lazily; "Run plugin" submenu lives under it.
+    QMenu *pluginMenu = nullptr;
     // Remembered base title (no dirty marker); refreshWindowTitle appends
     // "*" when annotations are unsaved.
     QString baseTitle;

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -42,9 +42,17 @@
 #include <QJsonObject>
 #include <QMessageBox>
 #include <QWheelEvent>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QDoubleSpinBox>
 #include <QFileDialog>
+#include <QFormLayout>
 #include <QGridLayout>
 #include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
 #include <QMenu>
 #include <QPainter>
 #include <QProgressDialog>
@@ -762,6 +770,15 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
     );
     menu.addAction(save);
 
+    // Add submenu to run external analysis plugins over a region of the tuned
+    // (filtered) signal. Plugins detect bursts / calls / sync etc. and return
+    // annotations. Discovered fresh each right-click so newly-installed manifests
+    // appear without a restart.
+    {
+        QMenu *pluginMenu = menu.addMenu("Run plugin");
+        buildPluginMenu(pluginMenu, [this](const PluginManifest &mf) { runPlugin(mf); });
+    }
+
     // Annotation actions: edit/delete if the click landed on one, or "Add
     // annotation here" otherwise (only on the spectrogram). The list is
     // accessed via the InputSource so saves and dirty-tracking flow through.
@@ -842,6 +859,235 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
         updateView(false);
 }
 
+
+bool PlotView::choosePluginScope(size_t &start, size_t &count)
+{
+    QDialog dlg(this);
+    dlg.setWindowTitle("Run plugin - region");
+    auto *layout = new QVBoxLayout(&dlg);
+    layout->addWidget(new QLabel("Run the plugin over:", &dlg));
+
+    auto *selRadio = new QRadioButton("Cursor selection", &dlg);
+    auto *viewRadio = new QRadioButton("Current view", &dlg);
+    auto *wholeRadio = new QRadioButton("Whole file", &dlg);
+    selRadio->setEnabled(cursorsEnabled);
+    if (cursorsEnabled)
+        selRadio->setChecked(true);
+    else
+        viewRadio->setChecked(true);
+    layout->addWidget(selRadio);
+    layout->addWidget(viewRadio);
+    layout->addWidget(wholeRadio);
+
+    auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dlg);
+    layout->addWidget(buttons);
+    connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+
+    if (dlg.exec() != QDialog::Accepted)
+        return false;
+
+    if (selRadio->isChecked()) {
+        start = selectedSamples.minimum;
+        count = selectedSamples.length();
+    } else if (viewRadio->isChecked()) {
+        start = viewRange.minimum;
+        count = viewRange.length();
+    } else {
+        start = 0;
+        count = mainSampleSource->count();
+    }
+    return true;
+}
+
+bool PlotView::collectPluginParams(const PluginManifest &manifest, QJsonObject &out)
+{
+    out = QJsonObject();
+    if (manifest.params.isEmpty())
+        return true;
+
+    QDialog dlg(this);
+    dlg.setWindowTitle(QString("%1 - parameters").arg(manifest.name));
+    auto *form = new QFormLayout(&dlg);
+
+    struct Field { const PluginParam *p; QWidget *w; };
+    std::vector<Field> fields;
+    for (const auto &p : manifest.params) {
+        QWidget *w = nullptr;
+        if (p.type == "int") {
+            auto *sb = new QSpinBox(&dlg);
+            sb->setRange(p.hasMin ? (int)p.minValue : -1000000000,
+                         p.hasMax ? (int)p.maxValue : 1000000000);
+            sb->setValue(p.defaultValue.toInt());
+            w = sb;
+        } else if (p.type == "float") {
+            auto *sb = new QDoubleSpinBox(&dlg);
+            sb->setDecimals(p.decimals > 0 ? p.decimals : 6);
+            sb->setRange(p.hasMin ? p.minValue : -1e12,
+                         p.hasMax ? p.maxValue : 1e12);
+            sb->setValue(p.defaultValue.toDouble());
+            w = sb;
+        } else if (p.type == "bool") {
+            auto *cb = new QCheckBox(&dlg);
+            cb->setChecked(p.defaultValue.toBool());
+            w = cb;
+        } else if (p.type == "enum") {
+            auto *combo = new QComboBox(&dlg);
+            combo->addItems(p.choices);
+            int idx = p.choices.indexOf(p.defaultValue.toString());
+            if (idx >= 0)
+                combo->setCurrentIndex(idx);
+            w = combo;
+        } else { // string (default)
+            auto *le = new QLineEdit(&dlg);
+            le->setText(p.defaultValue.toString());
+            w = le;
+        }
+        form->addRow(p.label, w);
+        fields.push_back({ &p, w });
+    }
+
+    auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dlg);
+    form->addRow(buttons);
+    connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+
+    if (dlg.exec() != QDialog::Accepted)
+        return false;
+
+    for (const auto &f : fields) {
+        const PluginParam &p = *f.p;
+        if (p.type == "int")
+            out.insert(p.key, static_cast<QSpinBox*>(f.w)->value());
+        else if (p.type == "float")
+            out.insert(p.key, static_cast<QDoubleSpinBox*>(f.w)->value());
+        else if (p.type == "bool")
+            out.insert(p.key, static_cast<QCheckBox*>(f.w)->isChecked());
+        else if (p.type == "enum")
+            out.insert(p.key, static_cast<QComboBox*>(f.w)->currentText());
+        else
+            out.insert(p.key, static_cast<QLineEdit*>(f.w)->text());
+    }
+    return true;
+}
+
+void PlotView::buildPluginMenu(QMenu *menu,
+                               const std::function<void(const PluginManifest &)> &onTrigger)
+{
+    int added = 0;
+    for (const auto &m : discoverPlugins()) {
+        if (!m.valid)
+            continue;
+        PluginManifest mf = m;
+        QObject::connect(menu->addAction(mf.name), &QAction::triggered, menu,
+                         [onTrigger, mf]() { onTrigger(mf); });
+        added++;
+    }
+    if (added == 0) {
+        QAction *none = menu->addAction(QObject::tr("No plugins in %1").arg(pluginDirectory()));
+        none->setEnabled(false);
+    }
+}
+
+void PlotView::runPlugin(const PluginManifest &manifest)
+{
+    if (mainSampleSource == nullptr || mainSampleSource->count() == 0) {
+        QMessageBox::information(this, "Run plugin", "No file is open.");
+        return;
+    }
+    if (pluginRunner && pluginRunner->running()) {
+        QMessageBox::information(this, "Run plugin",
+            "A plugin is already running. Wait for it to finish or cancel it.");
+        return;
+    }
+
+    // Source = the tuned/filtered IQ when the tuner is on, else the raw input
+    // (mirrors the "Export samples" behaviour). The pass-band gives default
+    // frequency bounds for annotations that don't specify their own.
+    auto *inputSrc = static_cast<InputSource*>(mainSampleSource);
+    std::shared_ptr<SampleSource<std::complex<float>>> src;
+    double centerFreq, passLo, passHi;
+    if (spectrogramPlot && spectrogramPlot->tunerEnabled()) {
+        src = std::dynamic_pointer_cast<SampleSource<std::complex<float>>>(spectrogramPlot->output());
+        const double centre = inputSrc->getFrequency() + spectrogramPlot->tunerOffsetHz();
+        const double half = 0.5 * spectrogramPlot->tunerBandwidthHz();
+        centerFreq = centre;
+        passLo = centre - half;
+        passHi = centre + half;
+    } else {
+        src = spectrogramPlot ? spectrogramPlot->input() : nullptr;
+        centerFreq = inputSrc->getFrequency();
+        passLo = centerFreq - 0.5 * sampleRate;
+        passHi = centerFreq + 0.5 * sampleRate;
+    }
+    if (!src) {
+        QMessageBox::warning(this, "Run plugin", "Could not access the sample source.");
+        return;
+    }
+
+    size_t start = 0, count = 0;
+    if (!choosePluginScope(start, count))
+        return;
+    if (count == 0) {
+        QMessageBox::information(this, "Run plugin", "The chosen region is empty.");
+        return;
+    }
+
+    // Warn before extracting a very large segment (it's written to a temp file
+    // on the GUI thread before the plugin runs).
+    const double bytes = (double)count * sizeof(std::complex<float>);
+    if (bytes > 512.0 * 1024 * 1024) {
+        auto r = QMessageBox::question(this, "Run plugin",
+            QString("This extracts %1 MiB of IQ to a temporary file. Continue?")
+                .arg(bytes / (1024.0 * 1024.0), 0, 'f', 0));
+        if (r != QMessageBox::Yes)
+            return;
+    }
+
+    QJsonObject params;
+    if (!collectPluginParams(manifest, params))
+        return;
+
+    if (!pluginRunner) {
+        pluginRunner = new PluginRunner(this);
+        connect(pluginRunner, &PluginRunner::finished, this,
+            [this](std::vector<Annotation> annos) {
+                if (pluginProgress)
+                    pluginProgress->reset();
+                auto *in = static_cast<InputSource*>(mainSampleSource);
+                for (const auto &a : annos)
+                    in->addAnnotation(a);
+                const QString msg = annos.empty()
+                    ? QStringLiteral("Plugin finished: no annotations returned.")
+                    : QString("Plugin added %1 annotation%2.")
+                          .arg(annos.size()).arg(annos.size() == 1 ? "" : "s");
+                QMessageBox::information(this, "Run plugin", msg);
+            });
+        connect(pluginRunner, &PluginRunner::failed, this,
+            [this](QString err) {
+                if (pluginProgress)
+                    pluginProgress->reset();
+                QMessageBox::warning(this, "Run plugin", "Plugin failed:\n" + err);
+            });
+    }
+
+    if (!pluginProgress) {
+        pluginProgress = new QProgressDialog(this);
+        pluginProgress->setWindowTitle("Run plugin");
+        pluginProgress->setRange(0, 0); // indeterminate / busy
+        pluginProgress->setMinimumDuration(0);
+        pluginProgress->setWindowModality(Qt::WindowModal);
+        connect(pluginProgress, &QProgressDialog::canceled, this, [this]() {
+            if (pluginRunner)
+                pluginRunner->cancel();
+        });
+    }
+    pluginProgress->setLabelText(QString("Running %1...").arg(manifest.name));
+    pluginProgress->show();
+
+    pluginRunner->run(manifest, src, start, count, sampleRate, centerFreq,
+                      passLo, passHi, params);
+}
 
 void PlotView::updateSelectionPlots()
 {

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "plotview.h"
+#include "amplitudedemod.h"
 #include "annotationdialog.h"
 #include "frequencydemod.h"
 #include "fskdemod.h"
@@ -253,6 +254,34 @@ void PlotView::setFmSquelch(int pct)
     if (periodTimer) periodTimer->start();
 }
 
+// Switch every AM (AmplitudeDemod) plot between linear power and dB.
+void PlotView::setAmDbMode(bool on)
+{
+    amDbMode = on;
+    for (auto &plt : plots) {
+        if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
+            if (auto am = dynamic_cast<AmplitudeDemod*>(tp->source().get()))
+                am->setDbMode(on);
+        }
+    }
+    QPixmapCache::clear();
+    viewport()->update();
+}
+
+// Full-scale reference (dBm) added to AM plots in dB mode. 0 = dBFS.
+void PlotView::setAmReferenceLevel(double dbm)
+{
+    amRefLevelDbm = dbm;
+    for (auto &plt : plots) {
+        if (auto tp = dynamic_cast<TracePlot*>(plt.get())) {
+            if (auto am = dynamic_cast<AmplitudeDemod*>(tp->source().get()))
+                am->setReferenceLevelDbm(dbm);
+        }
+    }
+    QPixmapCache::clear();
+    viewport()->update();
+}
+
 void PlotView::autoTuneFmLpf()
 {
     if (!spectrogramPlot || sampleRate <= 0.0) return;
@@ -455,6 +484,10 @@ void PlotView::addPlot(Plot *plot)
             fsk->setPredemodDecimation(fmPredemodDecim);
             fsk->setCheapDemod(fmFastDemod);
         }
+        if (auto am = dynamic_cast<AmplitudeDemod*>(tp->source().get())) {
+            am->setDbMode(amDbMode);
+            am->setReferenceLevelDbm(amRefLevelDbm);
+        }
     }
     if (auto fskp = dynamic_cast<FskPolarPlot*>(plot)) {
         fskp->setSymbolRate(symbolRateHz);
@@ -550,6 +583,14 @@ QString PlotView::sampleValueText(Plot *plot, size_t sampleIdx, double *rawValue
         if (dynamic_cast<FrequencyDemod*>(src.get())) {
             return QStringLiteral("%1Hz")
                 .arg(QString::fromStdString(formatSIValue(v)));
+        }
+        // AM in dB mode reads in dBFS, or dBm once a full-scale reference is
+        // set (ref 0 = dBFS by convention).
+        if (auto am = dynamic_cast<AmplitudeDemod*>(src.get())) {
+            if (am->dbMode()) {
+                const char *unit = (am->referenceLevelDbm() != 0.0) ? " dBm" : " dBFS";
+                return QString::number(v, 'f', 1) + QLatin1String(unit);
+            }
         }
         return QString::number(v, 'g', 6);
     }

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -1012,7 +1012,7 @@ void PlotView::runPlugin(const PluginManifest &manifest)
         QMessageBox::information(this, "Run plugin", "No file is open.");
         return;
     }
-    if (pluginRunner && pluginRunner->running()) {
+    if (pluginRunner && pluginRunner->busy()) {
         QMessageBox::information(this, "Run plugin",
             "A plugin is already running. Wait for it to finish or cancel it.");
         return;

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -976,21 +976,223 @@ void PlotView::onAnnotationsChanged()
     viewport()->update();
 }
 
+QRect PlotView::annotationViewportRect(const Annotation &a)
+{
+    if (!spectrogramPlot) return QRect();
+    const int hscroll = horizontalScrollBar()->value();
+    const int vscroll = verticalScrollBar()->value();
+    const int x0 = sampleToColumn(a.sampleRange.minimum) - hscroll;
+    const int x1 = sampleToColumn(a.sampleRange.maximum) - hscroll;
+    // Higher frequency = smaller y, so freqMax is the top edge.
+    const int yTop = spectrogramPlot->plotYAtFreq(a.frequencyRange.maximum) - vscroll;
+    const int yBot = spectrogramPlot->plotYAtFreq(a.frequencyRange.minimum) - vscroll;
+    return QRect(QPoint(x0, yTop), QPoint(x1, yBot)).normalized();
+}
+
+PlotView::AnnoGrab PlotView::grabForRect(const QRect &r, QPoint p) const
+{
+    const int M = 6; // edge/handle grab margin in px
+    const bool inX = p.x() >= r.left() - M && p.x() <= r.right() + M;
+    const bool inY = p.y() >= r.top() - M && p.y() <= r.bottom() + M;
+    if (!inX || !inY) return AnnoGrab::None;
+    const bool nL = std::abs(p.x() - r.left())   <= M;
+    const bool nR = std::abs(p.x() - r.right())  <= M;
+    const bool nT = std::abs(p.y() - r.top())    <= M;
+    const bool nB = std::abs(p.y() - r.bottom()) <= M;
+    if (nT && nL) return AnnoGrab::TopLeft;
+    if (nT && nR) return AnnoGrab::TopRight;
+    if (nB && nL) return AnnoGrab::BottomLeft;
+    if (nB && nR) return AnnoGrab::BottomRight;
+    if (nL) return AnnoGrab::Left;
+    if (nR) return AnnoGrab::Right;
+    if (nT) return AnnoGrab::Top;
+    if (nB) return AnnoGrab::Bottom;
+    return AnnoGrab::Move; // inside the body
+}
+
+Qt::CursorShape PlotView::cursorForGrab(AnnoGrab g) const
+{
+    switch (g) {
+        case AnnoGrab::Left:
+        case AnnoGrab::Right:        return Qt::SizeHorCursor;
+        case AnnoGrab::Top:
+        case AnnoGrab::Bottom:       return Qt::SizeVerCursor;
+        case AnnoGrab::TopLeft:
+        case AnnoGrab::BottomRight:  return Qt::SizeFDiagCursor;
+        case AnnoGrab::TopRight:
+        case AnnoGrab::BottomLeft:   return Qt::SizeBDiagCursor;
+        case AnnoGrab::Move:         return Qt::SizeAllCursor;
+        default:                     return Qt::ArrowCursor;
+    }
+}
+
+int PlotView::annotationGrabAt(QPoint pos, AnnoGrab *grabOut)
+{
+    if (!spectrogramPlot || !isOverSpectrogram(pos.y())) {
+        if (grabOut) *grabOut = AnnoGrab::None;
+        return -1;
+    }
+    auto inputSrc = static_cast<InputSource*>(mainSampleSource);
+    // Topmost (last drawn) wins, so iterate in reverse.
+    for (int i = (int)inputSrc->annotationList.size() - 1; i >= 0; --i) {
+        QRect r = annotationViewportRect(inputSrc->annotationList[i]);
+        AnnoGrab g = grabForRect(r, pos);
+        if (g != AnnoGrab::None) {
+            if (grabOut) *grabOut = g;
+            return i;
+        }
+    }
+    if (grabOut) *grabOut = AnnoGrab::None;
+    return -1;
+}
+
+long long PlotView::sampleAtViewportX(int vx)
+{
+    long long col = (long long)vx + horizontalScrollBar()->value();
+    if (col < 0) col = 0;
+    return col * (long long)samplesPerColumn();
+}
+
+double PlotView::freqAtViewportY(int vy) const
+{
+    if (!spectrogramPlot) return 0.0;
+    return spectrogramPlot->freqAtPlotY(vy + verticalScrollBar()->value());
+}
+
+void PlotView::updateAnnotationHover(QMouseEvent *event)
+{
+    AnnoGrab g = AnnoGrab::None;
+    int idx = annotationGrabAt(event->pos(), &g);
+    // Only claim the cursor while over an annotation; otherwise release it so
+    // the tuner / default cursor handling still works.
+    if (g != AnnoGrab::None)
+        viewport()->setCursor(cursorForGrab(g));
+    else
+        viewport()->unsetCursor();
+    if (idx != hoveredAnnotation) {
+        hoveredAnnotation = idx;
+        spectrogramPlot->setActiveAnnotation(idx);
+        viewport()->update();
+    }
+}
+
+bool PlotView::beginAnnotationEdit(QMouseEvent *event)
+{
+    AnnoGrab g = AnnoGrab::None;
+    int idx = annotationGrabAt(event->pos(), &g);
+    if (idx < 0 || g == AnnoGrab::None)
+        return false;
+    auto inputSrc = static_cast<InputSource*>(mainSampleSource);
+    editingAnnotation = idx;
+    editGrab = g;
+    editPressPos = event->pos();
+    editOrig = inputSrc->annotationList[idx];
+    spectrogramPlot->setActiveAnnotation(idx);
+    viewport()->setCursor(cursorForGrab(g));
+    return true;
+}
+
+void PlotView::updateAnnotationEdit(QMouseEvent *event)
+{
+    if (editingAnnotation < 0) return;
+    auto inputSrc = static_cast<InputSource*>(mainSampleSource);
+    if (editingAnnotation >= (int)inputSrc->annotationList.size()) {
+        editingAnnotation = -1;
+        return;
+    }
+
+    const long long count = (long long)inputSrc->count();
+    long long dS = sampleAtViewportX(event->pos().x()) - sampleAtViewportX(editPressPos.x());
+    double    dF = freqAtViewportY(event->pos().y()) - freqAtViewportY(editPressPos.y());
+
+    long long oMin = (long long)editOrig.sampleRange.minimum;
+    long long oMax = (long long)editOrig.sampleRange.maximum;
+    double    oLo  = editOrig.frequencyRange.minimum;
+    double    oHi  = editOrig.frequencyRange.maximum;
+    long long nMin = oMin, nMax = oMax;
+    double    nLo  = oLo,  nHi  = oHi;
+
+    switch (editGrab) {
+        case AnnoGrab::Move:
+            // Clamp the shift so the whole box stays within the file.
+            if (oMin + dS < 0) dS = -oMin;
+            if (count > 0 && oMax + dS > count - 1) dS = (count - 1) - oMax;
+            nMin = oMin + dS; nMax = oMax + dS;
+            nLo = oLo + dF;   nHi = oHi + dF;
+            break;
+        case AnnoGrab::Left:        nMin = oMin + dS; break;
+        case AnnoGrab::Right:       nMax = oMax + dS; break;
+        case AnnoGrab::Top:         nHi  = oHi + dF;  break; // top edge = higher freq
+        case AnnoGrab::Bottom:      nLo  = oLo + dF;  break;
+        case AnnoGrab::TopLeft:     nMin = oMin + dS; nHi = oHi + dF; break;
+        case AnnoGrab::TopRight:    nMax = oMax + dS; nHi = oHi + dF; break;
+        case AnnoGrab::BottomLeft:  nMin = oMin + dS; nLo = oLo + dF; break;
+        case AnnoGrab::BottomRight: nMax = oMax + dS; nLo = oLo + dF; break;
+        default: break;
+    }
+
+    if (nMin < 0) nMin = 0;
+    if (nMax < 0) nMax = 0;
+    if (count > 0) {
+        if (nMin > count - 1) nMin = count - 1;
+        if (nMax > count - 1) nMax = count - 1;
+    }
+    if (nMin > nMax) std::swap(nMin, nMax);
+    if (nLo > nHi)   std::swap(nLo, nHi);
+
+    Annotation &a = inputSrc->annotationList[editingAnnotation];
+    a.sampleRange = { (size_t)nMin, (size_t)nMax };
+    a.frequencyRange = { nLo, nHi };
+    viewport()->update();
+}
+
+void PlotView::finishAnnotationEdit(QMouseEvent *event)
+{
+    if (editingAnnotation < 0) return;
+    updateAnnotationEdit(event);
+    auto inputSrc = static_cast<InputSource*>(mainSampleSource);
+    const int idx = editingAnnotation;
+    editingAnnotation = -1;
+    editGrab = AnnoGrab::None;
+    if (idx >= 0 && idx < (int)inputSrc->annotationList.size()) {
+        // Commit through updateAnnotation so the dirty flag + change callbacks
+        // fire (enables Save, marks the title bar). The value is the one we
+        // edited live in place.
+        inputSrc->updateAnnotation(idx, inputSrc->annotationList[idx]);
+    }
+}
+
 bool PlotView::viewportEvent(QEvent *event) {
     if (event->type() == QEvent::MouseMove) {
         LatencyLog::mark("MouseMove ----------");
     } else if (event->type() == QEvent::Wheel) {
         LatencyLog::mark("Wheel ----------");
     }
-    // Shift+left-drag rectangle on the spectrogram → new annotation. Run
-    // before the per-plot dispatch so it doesn't accidentally drag the tuner.
+    // An in-progress annotation move/resize drag owns the mouse until release.
+    if (editingAnnotation >= 0) {
+        if (event->type() == QEvent::MouseMove) {
+            updateAnnotationEdit(static_cast<QMouseEvent*>(event));
+            return true;
+        }
+        if (event->type() == QEvent::MouseButtonRelease) {
+            finishAnnotationEdit(static_cast<QMouseEvent*>(event));
+            return true;
+        }
+    }
+
+    // Shift+left-drag on the spectrogram → new annotation; plain left-press on
+    // an existing annotation's box/handles → move/resize it. Both run before the
+    // per-plot dispatch so they don't drag the tuner. Hover (no button) shows
+    // the resize handles + cursor.
     if (event->type() == QEvent::MouseButtonPress) {
         auto *me = static_cast<QMouseEvent*>(event);
-        if (me->button() == Qt::LeftButton &&
-            (me->modifiers() & Qt::ShiftModifier) &&
-            spectrogramPlot &&
-            startAnnotationDrag(me)) {
-            return true;
+        if (me->button() == Qt::LeftButton && spectrogramPlot) {
+            if (me->modifiers() & Qt::ShiftModifier) {
+                if (startAnnotationDrag(me))
+                    return true;
+            } else if (beginAnnotationEdit(me)) {
+                return true;
+            }
         }
     } else if (event->type() == QEvent::MouseMove && annotDragging) {
         updateAnnotationDrag(static_cast<QMouseEvent*>(event));
@@ -998,6 +1200,10 @@ bool PlotView::viewportEvent(QEvent *event) {
     } else if (event->type() == QEvent::MouseButtonRelease && annotDragging) {
         finishAnnotationDrag(static_cast<QMouseEvent*>(event));
         return true;
+    } else if (event->type() == QEvent::MouseMove && spectrogramPlot) {
+        auto *me = static_cast<QMouseEvent*>(event);
+        if (me->buttons() == Qt::NoButton)
+            updateAnnotationHover(me);
     }
     // Handle wheel events for zooming (before the parent's handler to stop normal scrolling)
     if (event->type() == QEvent::Wheel) {

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -26,6 +26,7 @@
 #include "histogramplot.h"
 #include "util.h"
 #include <QPixmapCache>
+#include <algorithm>
 #include <climits>
 #include <cmath>
 #include <iostream>
@@ -916,8 +917,15 @@ bool PlotView::collectPluginParams(const PluginManifest &manifest, QJsonObject &
         QWidget *w = nullptr;
         if (p.type == "int") {
             auto *sb = new QSpinBox(&dlg);
-            sb->setRange(p.hasMin ? (int)p.minValue : -1000000000,
-                         p.hasMax ? (int)p.maxValue : 1000000000);
+            // Saturate the (double) manifest bounds into int range before casting;
+            // an out-of-int32 bound would otherwise be an out-of-range double->int
+            // conversion (UB). INT_MIN/INT_MAX are exactly representable as double.
+            auto toIntBound = [](double v) {
+                v = std::max((double)INT_MIN, std::min((double)INT_MAX, v));
+                return (int)v;
+            };
+            sb->setRange(p.hasMin ? toIntBound(p.minValue) : -1000000000,
+                         p.hasMax ? toIntBound(p.maxValue) : 1000000000);
             sb->setValue(p.defaultValue.toInt());
             w = sb;
         } else if (p.type == "float") {
@@ -974,14 +982,23 @@ bool PlotView::collectPluginParams(const PluginManifest &manifest, QJsonObject &
 void PlotView::buildPluginMenu(QMenu *menu,
                                const std::function<void(const PluginManifest &)> &onTrigger)
 {
+    menu->setToolTipsVisible(true);
     int added = 0;
     for (const auto &m : discoverPlugins()) {
         if (!m.valid)
             continue;
         PluginManifest mf = m;
-        QObject::connect(menu->addAction(mf.name), &QAction::triggered, menu,
-                         [onTrigger, mf]() { onTrigger(mf); });
+        QAction *act = menu->addAction(mf.name);
         added++;
+        // The extracted segment is always complex cf32; gate other declared types so
+        // a plugin can't be handed a format it didn't ask for.
+        if (mf.sampleType.compare("cf32", Qt::CaseInsensitive) != 0) {
+            act->setEnabled(false);
+            act->setToolTip(QObject::tr("unsupported sample_type \"%1\" (only cf32)")
+                                .arg(mf.sampleType));
+            continue;
+        }
+        QObject::connect(act, &QAction::triggered, menu, [onTrigger, mf]() { onTrigger(mf); });
     }
     if (added == 0) {
         QAction *none = menu->addAction(QObject::tr("No plugins in %1").arg(pluginDirectory()));
@@ -1033,8 +1050,8 @@ void PlotView::runPlugin(const PluginManifest &manifest)
         return;
     }
 
-    // Warn before extracting a very large segment (it's written to a temp file
-    // on the GUI thread before the plugin runs).
+    // Warn before extracting a very large segment (written to a temp file on a
+    // worker thread before the plugin runs; cancellable from the busy dialog).
     const double bytes = (double)count * sizeof(std::complex<float>);
     if (bytes > 512.0 * 1024 * 1024) {
         auto r = QMessageBox::question(this, "Run plugin",

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -95,6 +95,10 @@ public slots:
     void setFmPredemodDecimation(int m);
     // Amplitude squelch (% of window-peak |IQ|) for every FM plot. 0 = off.
     void setFmSquelch(int pct);
+    // Switch every AM plot between linear power and a dB scale.
+    void setAmDbMode(bool on);
+    // Full-scale reference (dBm) for AM plots in dB mode. 0 = dBFS.
+    void setAmReferenceLevel(double dbm);
     // Symbol rate (baud) for the FSK polar plot's differential delay. 0 = unset.
     void setSymbolRate(double baud);
     // Signal-strength gate (% of window peak) for the FSK polar constellation.
@@ -191,6 +195,10 @@ private:
     int    fmPredemodDecim = 1;
     bool   fmFastDemod = false;
     int    fmSquelchPct = 0; // amplitude squelch (% of window-peak |IQ|), 0 = off
+    // AM-plot display: dB scale toggle and full-scale reference (dBm; 0 = dBFS),
+    // re-applied to AM plots as they're added.
+    bool   amDbMode = false;
+    double amRefLevelDbm = 0.0;
     // Symbol rate (baud) re-applied to FSK polar plots as they're added. 0 = unset.
     double symbolRateHz = 0.0;
     // Constellation signal-strength gate (% of window peak), re-applied likewise.

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -29,9 +29,15 @@
 #include "cursors.h"
 #include "inputsource.h"
 #include "plot.h"
+#include "plugin.h"
 #include "samplesource.h"
 #include "spectrogramplot.h"
 #include "traceplot.h"
+
+#include <functional>
+
+class QProgressDialog;
+class QMenu;
 
 class PlotView : public QGraphicsView, Subscriber
 {
@@ -40,6 +46,16 @@ class PlotView : public QGraphicsView, Subscriber
 public:
     PlotView(InputSource *input);
     void setSampleRate(double rate);
+    // Run an external analysis plugin over a chosen region of the tuned/filtered
+    // signal and turn its returned annotations into editable annotations. Prompts
+    // for scope (selection / view / whole) and any declared params. Called from the
+    // right-click "Run plugin" submenu and the MainWindow Tools menu.
+    void runPlugin(const PluginManifest &manifest);
+    // Populate `menu` with one action per discovered valid plugin (or a disabled
+    // "no plugins" entry), each wired to call onTrigger with its manifest. Shared by
+    // the right-click submenu and the Tools menu so the two stay in sync.
+    static void buildPluginMenu(QMenu *menu,
+                                const std::function<void(const PluginManifest &)> &onTrigger);
 
 signals:
     void timeSelectionChanged(float time);
@@ -255,4 +271,17 @@ private:
     // Connected to InputSource::setAnnotationCallback in the constructor —
     // handles repaint, dirty title bar, dock save-button enable.
     void onAnnotationsChanged();
+
+    // --- External analysis plugins ---------------------------------------
+    // Ask the user which region to run a plugin over. Fills [start, count) in
+    // absolute samples and returns false if cancelled.
+    bool choosePluginScope(size_t &start, size_t &count);
+    // Build a param dialog from the manifest's declared params; fills `out` with
+    // the entered values (keyed by param key). Returns false if cancelled. With no
+    // declared params it returns true immediately with an empty object.
+    bool collectPluginParams(const PluginManifest &manifest, QJsonObject &out);
+    // One runner reused across runs (single-flight); progress dialog shown while
+    // a run is in flight.
+    PluginRunner *pluginRunner = nullptr;
+    QProgressDialog *pluginProgress = nullptr;
 };

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -215,6 +215,35 @@ private:
     bool startAnnotationDrag(QMouseEvent *event);
     void updateAnnotationDrag(QMouseEvent *event);
     void finishAnnotationDrag(QMouseEvent *event);
+
+    // --- Interactive bounds editing of an existing annotation ------------
+    // Which part of an annotation's box a point is grabbing: an edge/corner
+    // resizes that side, the body moves the whole box.
+    enum class AnnoGrab {
+        None, Move, Left, Right, Top, Bottom,
+        TopLeft, TopRight, BottomLeft, BottomRight
+    };
+    int      hoveredAnnotation = -1;   // drawn with handles; drives hover cursor
+    int      editingAnnotation = -1;   // currently being dragged (-1 = none)
+    AnnoGrab editGrab = AnnoGrab::None;
+    QPoint   editPressPos;             // viewport pos where the drag began
+    Annotation editOrig;               // annotation snapshot at drag start
+    // Viewport rectangle of an annotation's box at the current scroll/zoom.
+    QRect annotationViewportRect(const Annotation &a);
+    // Which grab region (if any) `pos` is over for box `r` (handle margin px).
+    AnnoGrab grabForRect(const QRect &r, QPoint pos) const;
+    Qt::CursorShape cursorForGrab(AnnoGrab g) const;
+    // Topmost annotation whose box/handles `pos` grabs; fills *grabOut. -1 none.
+    int annotationGrabAt(QPoint pos, AnnoGrab *grabOut);
+    // Map a viewport coordinate back to a sample index / absolute Hz.
+    long long sampleAtViewportX(int vx);
+    double freqAtViewportY(int vy) const;
+    // Hover (no button): set the active annotation + resize cursor.
+    void updateAnnotationHover(QMouseEvent *event);
+    // Press/drag/release on an annotation box to move or resize it.
+    bool beginAnnotationEdit(QMouseEvent *event);
+    void updateAnnotationEdit(QMouseEvent *event);
+    void finishAnnotationEdit(QMouseEvent *event);
     // Compose an annotation from a viewport rectangle and open the editor.
     // On accept, appends to the input source.
     void promptNewAnnotation(QRect viewportRect);

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -505,7 +505,7 @@ void PluginRunner::onReadyStderr()
         return;
     errBuf_.append(proc_->readAllStandardError());
     if (errBuf_.size() > kMaxStderrBytes)
-        errBuf_.truncate(kMaxStderrBytes); // keep the head, stay bounded
+        errBuf_ = errBuf_.right(kMaxStderrBytes); // keep the tail — tracebacks come last
 }
 
 void PluginRunner::onProcFinished(int exitCode, int exitStatus)
@@ -516,6 +516,8 @@ void PluginRunner::onProcFinished(int exitCode, int exitStatus)
     if (proc_) {
         outBuf_.append(proc_->readAllStandardOutput());
         errBuf_.append(proc_->readAllStandardError());
+        if (errBuf_.size() > kMaxStderrBytes)
+            errBuf_ = errBuf_.right(kMaxStderrBytes);
     }
     const QString errStr = QString::fromUtf8(errBuf_);
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,0 +1,493 @@
+/*
+ *  Copyright (C) 2026, Niklas Casaril <niklas@casaril.com>
+ *
+ *  This file is part of inspectrum.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "plugin.h"
+
+#include <QColor>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QProcess>
+#include <QSet>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QTimer>
+#include <algorithm>
+
+namespace {
+
+// Default colour for machine-detected annotations: a distinct cyan so they read as
+// plugin output until the user edits them. Annotations with an explicit
+// presentation:color override this.
+const QColor kDetectedColor(0, 200, 255, 180);
+
+// Convert a SigMF "#RRGGBBAA" colour to a QColor (Qt wants "#AARRGGBB"). Returns an
+// invalid QColor when the string isn't a valid colour, mirroring inputsource.cpp.
+QColor parseSigmfColor(const QString &s)
+{
+    QString c = s;
+    if ((c.length() == 9) && (c.at(0) == '#'))
+        c = "#" + c.mid(7, 2) + c.mid(1, 6);
+    if (QColor::isValidColor(c))
+        return QColor(c);
+    return QColor();
+}
+
+} // namespace
+
+QString pluginDirectory()
+{
+    QString base = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
+    if (base.isEmpty())
+        base = QDir::homePath() + "/.config";
+    return base + "/inspectrum/plugins";
+}
+
+PluginManifest parseManifest(const QByteArray &json, const QString &path)
+{
+    PluginManifest m;
+    m.path = path;
+
+    QJsonParseError perr;
+    QJsonDocument doc = QJsonDocument::fromJson(json, &perr);
+    if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
+        m.error = QString("invalid JSON: %1").arg(perr.errorString());
+        return m;
+    }
+    QJsonObject root = doc.object();
+
+    m.name = root["name"].toString();
+    m.exec = root["exec"].toString();
+    m.sampleType = root["sample_type"].toString("cf32");
+
+    if (m.name.isEmpty()) {
+        m.error = "manifest missing \"name\"";
+        return m;
+    }
+    if (m.exec.isEmpty()) {
+        m.error = "manifest missing \"exec\"";
+        return m;
+    }
+
+    for (const auto &a : root["args"].toArray())
+        m.args << a.toString();
+
+    QSet<QString> seenKeys;
+    for (const auto &pv : root["params"].toArray()) {
+        QJsonObject po = pv.toObject();
+        PluginParam p;
+        p.key = po["key"].toString();
+        if (p.key.isEmpty())
+            continue; // a param with no key is useless; skip it
+        if (seenKeys.contains(p.key)) {
+            // Duplicate keys would collide in the emitted custom_params object
+            // (last value wins); skip the later one and warn rather than confuse.
+            qWarning() << "inspectrum: plugin manifest" << path
+                       << "has duplicate param key" << p.key << "- ignoring the later one";
+            continue;
+        }
+        seenKeys.insert(p.key);
+        p.type = po["type"].toString("string");
+        p.label = po["label"].toString(p.key);
+        p.defaultValue = po["default"];
+        for (const auto &c : po["choices"].toArray())
+            p.choices << c.toString();
+        if (po.contains("min")) { p.hasMin = true; p.minValue = po["min"].toDouble(); }
+        if (po.contains("max")) { p.hasMax = true; p.maxValue = po["max"].toDouble(); }
+        p.decimals = po["decimals"].toInt(6);
+        m.params.push_back(p);
+    }
+
+    m.valid = true;
+    return m;
+}
+
+QVector<PluginManifest> discoverPlugins()
+{
+    QVector<PluginManifest> result;
+    QDir dir(pluginDirectory());
+    if (!dir.exists())
+        return result;
+
+    const auto entries = dir.entryList(QStringList() << "*.json", QDir::Files, QDir::Name);
+    for (const QString &name : entries) {
+        const QString path = dir.absoluteFilePath(name);
+        QFile f(path);
+        if (!f.open(QIODevice::ReadOnly)) {
+            qWarning() << "inspectrum: cannot read plugin manifest" << path;
+            continue;
+        }
+        PluginManifest m = parseManifest(f.readAll(), path);
+        if (!m.valid)
+            qWarning() << "inspectrum: skipping plugin manifest" << path << ":" << m.error;
+        result.push_back(m);
+    }
+    return result;
+}
+
+bool writeSegmentSigmf(const QString &dir,
+                       SampleSource<std::complex<float>> *src,
+                       size_t start, size_t count,
+                       double sampleRate, double centerFreq,
+                       QString *metaPathOut, QString *dataPathOut,
+                       QString *errorOut)
+{
+    auto setErr = [&](const QString &e) { if (errorOut) *errorOut = e; };
+
+    if (src == nullptr) {
+        setErr("no sample source");
+        return false;
+    }
+    if (count == 0) {
+        setErr("empty segment");
+        return false;
+    }
+
+    const QString dataName = "segment.sigmf-data";
+    const QString metaName = "segment.sigmf-meta";
+    const QString dataPath = QDir(dir).absoluteFilePath(dataName);
+    const QString metaPath = QDir(dir).absoluteFilePath(metaName);
+
+    // Write the cf32 IQ. std::complex<float> is two contiguous little-endian float32
+    // (I then Q), which is exactly the cf32_le on-disk layout inspectrum reads, so we
+    // can blit the buffer bytes directly. Pull in chunks to bound memory.
+    {
+        QFile data(dataPath);
+        if (!data.open(QIODevice::WriteOnly)) {
+            setErr(QString("cannot open %1 for writing").arg(dataPath));
+            return false;
+        }
+        const size_t chunk = 1u << 20; // 1 Msample = 8 MiB per pull
+        for (size_t off = 0; off < count; off += chunk) {
+            const size_t n = std::min(chunk, count - off);
+            auto buf = src->getSamples(start + off, n);
+            if (!buf) {
+                setErr("sample source returned no data (out of range?)");
+                data.close();
+                data.remove();
+                return false;
+            }
+            const char *bytes = reinterpret_cast<const char *>(buf.get());
+            qint64 want = (qint64)(n * sizeof(std::complex<float>));
+            if (data.write(bytes, want) != want) {
+                setErr(QString("short write to %1").arg(dataPath));
+                data.close();
+                data.remove();
+                return false;
+            }
+        }
+    }
+
+    // Write the matching .sigmf-meta (global + one capture carrying the absolute
+    // centre frequency + an empty annotations array).
+    {
+        QJsonObject global;
+        global.insert("core:datatype", QStringLiteral("cf32_le"));
+        if (sampleRate > 0.0)
+            global.insert("core:sample_rate", sampleRate);
+        global.insert("core:version", QStringLiteral("1.0.0"));
+        global.insert("core:dataset", dataName);
+        global.insert("core:description",
+                      QStringLiteral("Filtered segment extracted by inspectrum"));
+
+        QJsonObject capture;
+        capture.insert("core:sample_start", (qint64)0);
+        capture.insert("core:frequency", centerFreq);
+        QJsonArray captures;
+        captures.append(capture);
+
+        QJsonObject root;
+        root.insert("global", global);
+        root.insert("captures", captures);
+        root.insert("annotations", QJsonArray());
+
+        QFile meta(metaPath);
+        if (!meta.open(QIODevice::WriteOnly)) {
+            setErr(QString("cannot open %1 for writing").arg(metaPath));
+            return false;
+        }
+        const QByteArray json = QJsonDocument(root).toJson(QJsonDocument::Indented);
+        if (meta.write(json) != json.size()) {
+            setErr(QString("short write to %1").arg(metaPath));
+            return false;
+        }
+    }
+
+    if (metaPathOut) *metaPathOut = metaPath;
+    if (dataPathOut) *dataPathOut = dataPath;
+    return true;
+}
+
+std::vector<Annotation> parsePluginAnnotations(const QByteArray &json,
+                                               size_t segStart, size_t segCount,
+                                               double passLo, double passHi,
+                                               QString *errorOut)
+{
+    std::vector<Annotation> out;
+    if (errorOut) errorOut->clear();
+
+    QJsonParseError perr;
+    QJsonDocument doc = QJsonDocument::fromJson(json, &perr);
+    if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
+        if (errorOut)
+            *errorOut = QString("invalid JSON: %1").arg(perr.errorString());
+        return out;
+    }
+
+    const QJsonArray annotations = doc.object()["annotations"].toArray();
+    for (const auto &av : annotations) {
+        QJsonObject a = av.toObject();
+        // core:sample_start and core:sample_count are required; skip entries missing
+        // either rather than failing the whole batch.
+        if (!a.contains("core:sample_start") || !a.contains("core:sample_count"))
+            continue;
+        const double dStart = a["core:sample_start"].toDouble(-1.0);
+        const double dCount = a["core:sample_count"].toDouble(-1.0);
+        // Validate the DOUBLES against the segment before any cast to size_t: a
+        // hostile/buggy plugin can emit huge or fractional values, and an
+        // out-of-range double->size_t conversion is undefined behaviour. Bounds:
+        // start must land inside the segment, count must be at least one sample.
+        if (!(dStart >= 0.0) || dStart >= (double)segCount)
+            continue;
+        if (!(dCount >= 1.0))
+            continue;
+
+        const size_t localStart = (size_t)dStart;       // safe: 0 <= dStart < segCount
+        const size_t maxCnt = segCount - localStart;     // samples left in the segment
+        // Clamp the count so the inclusive max can neither wrap nor exceed the last
+        // valid file sample (segStart + segCount - 1). Comparing the double avoids
+        // casting an over-large value.
+        const size_t cnt = (dCount >= (double)maxCnt) ? maxCnt : (size_t)dCount;
+        const size_t absStart = segStart + localStart;
+        const size_t absMax = absStart + cnt - 1; // inclusive, matches sampleRange
+
+        // Frequency edges are absolute Hz. SigMF requires both-or-neither; fall back
+        // to the tuner pass-band when either is absent.
+        double fLo = passLo, fHi = passHi;
+        if (a.contains("core:freq_lower_edge") && a.contains("core:freq_upper_edge")) {
+            fLo = a["core:freq_lower_edge"].toDouble();
+            fHi = a["core:freq_upper_edge"].toDouble();
+        }
+        if (fHi < fLo)
+            std::swap(fLo, fHi);
+
+        QColor color = parseSigmfColor(a["presentation:color"].toString());
+        if (!color.isValid())
+            color = kDetectedColor;
+
+        Annotation ann;
+        ann.sampleRange = { absStart, absMax };
+        ann.frequencyRange = { fLo, fHi };
+        ann.label = a["core:label"].toString();
+        ann.description = a["core:description"].toString();
+        ann.comment = a["core:comment"].toString();
+        ann.boxColor = color;
+        out.push_back(ann);
+    }
+
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+
+PluginRunner::PluginRunner(QObject *parent) : QObject(parent) {}
+
+PluginRunner::~PluginRunner()
+{
+    cleanup();
+}
+
+void PluginRunner::run(const PluginManifest &manifest,
+                       std::shared_ptr<SampleSource<std::complex<float>>> src,
+                       size_t start, size_t count,
+                       double sampleRate, double centerFreq,
+                       double passLo, double passHi,
+                       const QJsonObject &customParams,
+                       int timeoutMs)
+{
+    if (running_) {
+        emit failed("a plugin is already running");
+        return;
+    }
+    if (!src) {
+        emit failed("no sample source available");
+        return;
+    }
+
+    const size_t total = src->count();
+    if (start >= total) {
+        emit failed("selection starts past the end of the file");
+        return;
+    }
+    if (start + count > total)
+        count = total - start;
+    if (count == 0) {
+        emit failed("empty selection");
+        return;
+    }
+
+    running_ = true;
+    segStart_ = start;
+    segCount_ = count;   // already clamped to [start, total) above
+    passLo_ = passLo;
+    passHi_ = passHi;
+
+    tmpDir_.reset(new QTemporaryDir());
+    if (!tmpDir_->isValid()) {
+        fail("could not create a temporary directory for the segment");
+        return;
+    }
+
+    QString metaPath, err;
+    if (!writeSegmentSigmf(tmpDir_->path(), src.get(), start, count,
+                           sampleRate, centerFreq, &metaPath, nullptr, &err)) {
+        fail(err.isEmpty() ? "failed to write segment" : err);
+        return;
+    }
+
+    QJsonObject ctx;
+    ctx.insert("sample_rate", sampleRate);
+    ctx.insert("center_freq", centerFreq);
+    ctx.insert("custom_params", customParams);
+    const QByteArray ctxJson = QJsonDocument(ctx).toJson(QJsonDocument::Compact);
+
+    proc_ = new QProcess(this);
+    proc_->setWorkingDirectory(tmpDir_->path());
+
+    connect(proc_, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this](int code, QProcess::ExitStatus st) {
+                onProcFinished(code, (int)st);
+            });
+    connect(proc_, &QProcess::errorOccurred,
+            this, [this](QProcess::ProcessError) { onProcErrorOccurred(); });
+    // Feed context.json on stdin once the process is up, then signal EOF.
+    connect(proc_, &QProcess::started, this, [this, ctxJson]() {
+        if (proc_) {
+            proc_->write(ctxJson);
+            proc_->closeWriteChannel();
+        }
+    });
+
+    QStringList args = manifest.args;
+    args << metaPath;
+
+    if (timeoutMs > 0) {
+        timeoutTimer_ = new QTimer(this);
+        timeoutTimer_->setSingleShot(true);
+        connect(timeoutTimer_, &QTimer::timeout, this, &PluginRunner::onTimeout);
+        timeoutTimer_->start(timeoutMs);
+    }
+
+    proc_->start(manifest.exec, args);
+}
+
+void PluginRunner::onProcFinished(int exitCode, int exitStatus)
+{
+    if (!running_)
+        return;
+
+    QByteArray out = proc_ ? proc_->readAllStandardOutput() : QByteArray();
+    QByteArray errOut = proc_ ? proc_->readAllStandardError() : QByteArray();
+
+    if (exitStatus != (int)QProcess::NormalExit) {
+        fail(QString("plugin crashed%1")
+                 .arg(errOut.isEmpty() ? QString() : ":\n" + QString::fromUtf8(errOut)));
+        return;
+    }
+    if (exitCode != 0) {
+        fail(QString("plugin exited with code %1%2")
+                 .arg(exitCode)
+                 .arg(errOut.isEmpty() ? QString() : ":\n" + QString::fromUtf8(errOut)));
+        return;
+    }
+
+    QString perr;
+    std::vector<Annotation> annos =
+        parsePluginAnnotations(out, segStart_, segCount_, passLo_, passHi_, &perr);
+    if (!perr.isEmpty()) {
+        fail(QString("could not parse plugin output: %1%2")
+                 .arg(perr)
+                 .arg(errOut.isEmpty() ? QString() : "\n" + QString::fromUtf8(errOut)));
+        return;
+    }
+
+    running_ = false;
+    cleanup();
+    emit finished(annos);
+}
+
+void PluginRunner::onProcErrorOccurred()
+{
+    if (!running_ || !proc_)
+        return;
+    // A failed launch never produces finished(); other errors (e.g. Crashed) do, so
+    // we only own FailedToStart here.
+    if (proc_->error() == QProcess::FailedToStart)
+        fail(QString("failed to start plugin: %1").arg(proc_->errorString()));
+}
+
+void PluginRunner::onTimeout()
+{
+    if (!running_)
+        return;
+    if (proc_)
+        proc_->kill();
+    fail("plugin timed out");
+}
+
+void PluginRunner::cancel()
+{
+    if (!running_)
+        return;
+    // running_=false + cleanup() (which disconnect()s proc_ before deleteLater)
+    // suppresses the finished()/failed() that the killed process would otherwise
+    // trigger, so no explicit "canceled" flag is needed.
+    running_ = false;
+    if (proc_)
+        proc_->kill();
+    cleanup();
+}
+
+void PluginRunner::fail(const QString &error)
+{
+    if (!running_)
+        return;
+    running_ = false;
+    cleanup();
+    emit failed(error);
+}
+
+void PluginRunner::cleanup()
+{
+    if (timeoutTimer_) {
+        timeoutTimer_->stop();
+        timeoutTimer_->deleteLater();
+        timeoutTimer_ = nullptr;
+    }
+    if (proc_) {
+        proc_->disconnect(this);
+        proc_->deleteLater();
+        proc_ = nullptr;
+    }
+    tmpDir_.reset();
+}

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -519,6 +519,13 @@ void PluginRunner::onProcFinished(int exitCode, int exitStatus)
         if (errBuf_.size() > kMaxStderrBytes)
             errBuf_ = errBuf_.right(kMaxStderrBytes);
     }
+    // The final drain can push stdout just past the cap; enforce it here too
+    // (can't tail-truncate stdout — that would corrupt the leading JSON).
+    if (outBuf_.size() > kMaxStdoutBytes) {
+        fail(QString("plugin produced too much output (> %1 MiB)")
+                 .arg(kMaxStdoutBytes / (1024 * 1024)));
+        return;
+    }
     const QString errStr = QString::fromUtf8(errBuf_);
 
     if (exitStatus != (int)QProcess::NormalExit) {

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -353,7 +353,10 @@ void PluginRunner::run(const PluginManifest &manifest,
                        const QJsonObject &customParams,
                        int timeoutMs)
 {
-    if (running_) {
+    if (running_ || canceling_) {
+        // canceling_: a previous run was cancelled mid-extraction and its worker
+        // hasn't been joined yet. Starting now would reset extractCancel_ and delete
+        // tmpDir_ out from under that live worker.
         emit failed("a plugin is already running");
         return;
     }
@@ -428,6 +431,10 @@ void PluginRunner::run(const PluginManifest &manifest,
 void PluginRunner::onExtractFinished()
 {
     if (!extractWatcher_)
+        return;
+    // Defence in depth: ignore a finished() from an orphaned watcher that is no
+    // longer the current one (the busy() guard should already prevent this).
+    if (sender() != nullptr && sender() != extractWatcher_)
         return;
     const SegmentExtract r = extractWatcher_->result();
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -32,7 +32,14 @@
 #include <QStandardPaths>
 #include <QTemporaryDir>
 #include <QTimer>
+#include <QtConcurrent>
 #include <algorithm>
+
+// Bound how much child output we accumulate so a runaway/verbose plugin cannot
+// exhaust the GUI process's memory, and how many annotations one run may add.
+static const int kMaxStdoutBytes = 64 * 1024 * 1024;
+static const int kMaxStderrBytes = 1 * 1024 * 1024;
+static const size_t kMaxAnnotations = 100000;
 
 namespace {
 
@@ -88,6 +95,13 @@ PluginManifest parseManifest(const QByteArray &json, const QString &path)
         m.error = "manifest missing \"exec\"";
         return m;
     }
+    // The child is launched with its working directory set to a fresh temp dir, so a
+    // relative path containing a separator (e.g. "./plugin.py") would resolve against
+    // that empty dir and fail. Resolve such a path against the manifest's own
+    // directory so a script can be colocated with its manifest. Absolute paths and
+    // bare PATH-resolvable names are left untouched.
+    if (QDir::isRelativePath(m.exec) && m.exec.contains('/'))
+        m.exec = QFileInfo(path).absoluteDir().absoluteFilePath(m.exec);
 
     for (const auto &a : root["args"].toArray())
         m.args << a.toString();
@@ -150,7 +164,8 @@ bool writeSegmentSigmf(const QString &dir,
                        size_t start, size_t count,
                        double sampleRate, double centerFreq,
                        QString *metaPathOut, QString *dataPathOut,
-                       QString *errorOut)
+                       QString *errorOut,
+                       const std::atomic<bool> *cancel)
 {
     auto setErr = [&](const QString &e) { if (errorOut) *errorOut = e; };
 
@@ -179,6 +194,12 @@ bool writeSegmentSigmf(const QString &dir,
         }
         const size_t chunk = 1u << 20; // 1 Msample = 8 MiB per pull
         for (size_t off = 0; off < count; off += chunk) {
+            if (cancel && cancel->load()) {
+                setErr("canceled");
+                data.close();
+                data.remove();
+                return false;
+            }
             const size_t n = std::min(chunk, count - off);
             auto buf = src->getSamples(start + off, n);
             if (!buf) {
@@ -229,6 +250,8 @@ bool writeSegmentSigmf(const QString &dir,
         const QByteArray json = QJsonDocument(root).toJson(QJsonDocument::Indented);
         if (meta.write(json) != json.size()) {
             setErr(QString("short write to %1").arg(metaPath));
+            meta.close();
+            meta.remove();
             return false;
         }
     }
@@ -256,6 +279,11 @@ std::vector<Annotation> parsePluginAnnotations(const QByteArray &json,
 
     const QJsonArray annotations = doc.object()["annotations"].toArray();
     for (const auto &av : annotations) {
+        if (out.size() >= kMaxAnnotations) {
+            qWarning() << "inspectrum: plugin returned more than" << (int)kMaxAnnotations
+                       << "annotations; ignoring the rest";
+            break;
+        }
         QJsonObject a = av.toObject();
         // core:sample_start and core:sample_count are required; skip entries missing
         // either rather than failing the whole batch.
@@ -347,10 +375,24 @@ void PluginRunner::run(const PluginManifest &manifest,
     }
 
     running_ = true;
+    canceling_ = false;
+    extractCancel_ = false;
+    outBuf_.clear();
+    errBuf_.clear();
     segStart_ = start;
     segCount_ = count;   // already clamped to [start, total) above
     passLo_ = passLo;
     passHi_ = passHi;
+    timeoutMs_ = timeoutMs;
+
+    // Stash what launchProcess() needs once extraction completes.
+    exec_ = manifest.exec;
+    args_ = manifest.args;
+    QJsonObject ctx;
+    ctx.insert("sample_rate", sampleRate);
+    ctx.insert("center_freq", centerFreq);
+    ctx.insert("custom_params", customParams);
+    contextJson_ = QJsonDocument(ctx).toJson(QJsonDocument::Compact);
 
     tmpDir_.reset(new QTemporaryDir());
     if (!tmpDir_->isValid()) {
@@ -358,19 +400,54 @@ void PluginRunner::run(const PluginManifest &manifest,
         return;
     }
 
-    QString metaPath, err;
-    if (!writeSegmentSigmf(tmpDir_->path(), src.get(), start, count,
-                           sampleRate, centerFreq, &metaPath, nullptr, &err)) {
-        fail(err.isEmpty() ? "failed to write segment" : err);
+    // Extract the segment on a worker thread so the GUI event loop keeps running
+    // (the busy dialog repaints, Cancel works) even for a whole-file (100GB+) scope.
+    const QString dir = tmpDir_->path();
+    std::atomic<bool> *cancelPtr = &extractCancel_;
+    extractWatcher_ = new QFutureWatcher<SegmentExtract>(this);
+    connect(extractWatcher_, &QFutureWatcher<SegmentExtract>::finished,
+            this, &PluginRunner::onExtractFinished);
+    extractWatcher_->setFuture(QtConcurrent::run(
+        [src, start, count, sampleRate, centerFreq, dir, cancelPtr]() -> SegmentExtract {
+            SegmentExtract r;
+            QString metaPath, err;
+            const bool ok = writeSegmentSigmf(dir, src.get(), start, count,
+                                              sampleRate, centerFreq,
+                                              &metaPath, nullptr, &err, cancelPtr);
+            if (!ok && err == "canceled") {
+                r.canceled = true;
+                return r;
+            }
+            r.ok = ok;
+            r.metaPath = metaPath;
+            r.error = err;
+            return r;
+        }));
+}
+
+void PluginRunner::onExtractFinished()
+{
+    if (!extractWatcher_)
+        return;
+    const SegmentExtract r = extractWatcher_->result();
+
+    // Cancelled (or already terminal) while extracting: the worker has returned, so
+    // it is now safe to delete the temp dir. Emit nothing for a user cancel.
+    if (canceling_ || !running_ || r.canceled) {
+        canceling_ = false;
+        running_ = false;
+        cleanup();
         return;
     }
+    if (!r.ok) {
+        fail(r.error.isEmpty() ? "failed to write segment" : r.error);
+        return;
+    }
+    launchProcess(r.metaPath);
+}
 
-    QJsonObject ctx;
-    ctx.insert("sample_rate", sampleRate);
-    ctx.insert("center_freq", centerFreq);
-    ctx.insert("custom_params", customParams);
-    const QByteArray ctxJson = QJsonDocument(ctx).toJson(QJsonDocument::Compact);
-
+void PluginRunner::launchProcess(const QString &metaPath)
+{
     proc_ = new QProcess(this);
     proc_->setWorkingDirectory(tmpDir_->path());
 
@@ -380,25 +457,48 @@ void PluginRunner::run(const PluginManifest &manifest,
             });
     connect(proc_, &QProcess::errorOccurred,
             this, [this](QProcess::ProcessError) { onProcErrorOccurred(); });
+    connect(proc_, &QProcess::readyReadStandardOutput, this, &PluginRunner::onReadyStdout);
+    connect(proc_, &QProcess::readyReadStandardError, this, &PluginRunner::onReadyStderr);
     // Feed context.json on stdin once the process is up, then signal EOF.
-    connect(proc_, &QProcess::started, this, [this, ctxJson]() {
+    connect(proc_, &QProcess::started, this, [this]() {
         if (proc_) {
-            proc_->write(ctxJson);
+            proc_->write(contextJson_);
             proc_->closeWriteChannel();
         }
     });
 
-    QStringList args = manifest.args;
+    QStringList args = args_;
     args << metaPath;
 
-    if (timeoutMs > 0) {
+    if (timeoutMs_ > 0) {
         timeoutTimer_ = new QTimer(this);
         timeoutTimer_->setSingleShot(true);
         connect(timeoutTimer_, &QTimer::timeout, this, &PluginRunner::onTimeout);
-        timeoutTimer_->start(timeoutMs);
+        timeoutTimer_->start(timeoutMs_);
     }
 
-    proc_->start(manifest.exec, args);
+    proc_->start(exec_, args);
+}
+
+void PluginRunner::onReadyStdout()
+{
+    if (!proc_)
+        return;
+    outBuf_.append(proc_->readAllStandardOutput());
+    if (outBuf_.size() > kMaxStdoutBytes) {
+        proc_->kill();
+        fail(QString("plugin produced too much output (> %1 MiB)")
+                 .arg(kMaxStdoutBytes / (1024 * 1024)));
+    }
+}
+
+void PluginRunner::onReadyStderr()
+{
+    if (!proc_)
+        return;
+    errBuf_.append(proc_->readAllStandardError());
+    if (errBuf_.size() > kMaxStderrBytes)
+        errBuf_.truncate(kMaxStderrBytes); // keep the head, stay bounded
 }
 
 void PluginRunner::onProcFinished(int exitCode, int exitStatus)
@@ -406,28 +506,36 @@ void PluginRunner::onProcFinished(int exitCode, int exitStatus)
     if (!running_)
         return;
 
-    QByteArray out = proc_ ? proc_->readAllStandardOutput() : QByteArray();
-    QByteArray errOut = proc_ ? proc_->readAllStandardError() : QByteArray();
+    if (proc_) {
+        outBuf_.append(proc_->readAllStandardOutput());
+        errBuf_.append(proc_->readAllStandardError());
+    }
+    const QString errStr = QString::fromUtf8(errBuf_);
 
     if (exitStatus != (int)QProcess::NormalExit) {
-        fail(QString("plugin crashed%1")
-                 .arg(errOut.isEmpty() ? QString() : ":\n" + QString::fromUtf8(errOut)));
+        fail(QString("plugin crashed%1").arg(errStr.isEmpty() ? QString() : ":\n" + errStr));
         return;
     }
     if (exitCode != 0) {
         fail(QString("plugin exited with code %1%2")
-                 .arg(exitCode)
-                 .arg(errOut.isEmpty() ? QString() : ":\n" + QString::fromUtf8(errOut)));
+                 .arg(exitCode).arg(errStr.isEmpty() ? QString() : ":\n" + errStr));
+        return;
+    }
+
+    // A clean exit with no stdout is a zero-detection run, not a parse failure.
+    if (outBuf_.trimmed().isEmpty()) {
+        running_ = false;
+        cleanup();
+        emit finished({});
         return;
     }
 
     QString perr;
     std::vector<Annotation> annos =
-        parsePluginAnnotations(out, segStart_, segCount_, passLo_, passHi_, &perr);
+        parsePluginAnnotations(outBuf_, segStart_, segCount_, passLo_, passHi_, &perr);
     if (!perr.isEmpty()) {
         fail(QString("could not parse plugin output: %1%2")
-                 .arg(perr)
-                 .arg(errOut.isEmpty() ? QString() : "\n" + QString::fromUtf8(errOut)));
+                 .arg(perr).arg(errStr.isEmpty() ? QString() : "\n" + errStr));
         return;
     }
 
@@ -459,13 +567,20 @@ void PluginRunner::cancel()
 {
     if (!running_)
         return;
-    // running_=false + cleanup() (which disconnect()s proc_ before deleteLater)
-    // suppresses the finished()/failed() that the killed process would otherwise
-    // trigger, so no explicit "canceled" flag is needed.
-    running_ = false;
-    if (proc_)
+    extractCancel_ = true; // ask any in-flight extraction worker to stop
+    if (proc_) {
+        // Process phase: killing it + cleanup() (which disconnects before deleteLater)
+        // suppresses the finished()/failed() the kill would otherwise trigger.
+        running_ = false;
         proc_->kill();
-    cleanup();
+        cleanup();
+    } else {
+        // Extraction phase: the worker may still be writing tmpDir_, so we cannot
+        // delete it yet. Mark cancelling and let onExtractFinished() tidy up once the
+        // worker observes extractCancel_ and returns.
+        canceling_ = true;
+        running_ = false;
+    }
 }
 
 void PluginRunner::fail(const QString &error)
@@ -473,6 +588,7 @@ void PluginRunner::fail(const QString &error)
     if (!running_)
         return;
     running_ = false;
+    canceling_ = false;
     cleanup();
     emit failed(error);
 }
@@ -483,6 +599,16 @@ void PluginRunner::cleanup()
         timeoutTimer_->stop();
         timeoutTimer_->deleteLater();
         timeoutTimer_ = nullptr;
+    }
+    if (extractWatcher_) {
+        // Make sure no worker is still touching tmpDir_ before we remove it. If the
+        // future already finished (the common case) this returns immediately;
+        // otherwise extractCancel_ makes the worker bail at the next chunk.
+        extractCancel_ = true;
+        extractWatcher_->waitForFinished();
+        extractWatcher_->disconnect(this);
+        extractWatcher_->deleteLater();
+        extractWatcher_ = nullptr;
     }
     if (proc_) {
         proc_->disconnect(this);

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (C) 2026, Niklas Casaril <niklas@casaril.com>
+ *
+ *  This file is part of inspectrum.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <complex>
+#include <memory>
+#include <vector>
+#include "samplesource.h"
+
+class QProcess;
+class QTimer;
+class QTemporaryDir;
+
+// One declared parameter of a plugin (drives the auto-generated param dialog).
+struct PluginParam {
+    QString key;            // JSON key handed to the plugin in custom_params
+    QString type;           // "float" | "int" | "bool" | "string" | "enum"
+    QString label;          // dialog label (falls back to key)
+    QJsonValue defaultValue;
+    QStringList choices;    // for type == "enum"
+    // Optional numeric bounds / precision for int/float widgets. When a bound is
+    // absent the dialog uses a wide default; declaring them avoids silent clamping
+    // or rounding of out-of-range / small-magnitude values.
+    bool hasMin = false;
+    bool hasMax = false;
+    double minValue = 0.0;
+    double maxValue = 0.0;
+    int decimals = 6;       // float precision
+};
+
+// A discovered plugin manifest (~/.config/inspectrum/plugins/*.json).
+struct PluginManifest {
+    QString name;
+    QString exec;           // absolute path or PATH-resolvable executable
+    QStringList args;       // fixed args prepended before the meta-file path
+    QString sampleType;     // accepted input sample type, e.g. "cf32"
+    QVector<PluginParam> params;
+    QString path;           // manifest file path (for diagnostics)
+    bool valid = false;
+    QString error;          // why it's invalid, if !valid
+};
+
+// Directory plugins are discovered from: ~/.config/inspectrum/plugins
+QString pluginDirectory();
+
+// Parse a single manifest blob. Always returns a manifest; check .valid/.error.
+PluginManifest parseManifest(const QByteArray &json, const QString &path);
+
+// Discover and parse every *.json manifest in pluginDirectory().
+QVector<PluginManifest> discoverPlugins();
+
+// Write a temporary SigMF segment (cf32_le .sigmf-data + .sigmf-meta) for samples
+// [start, start+count) pulled from `src`. The meta carries core:sample_rate and
+// captures[0].core:frequency = centerFreq (absolute Hz). Returns false + *errorOut
+// on failure. metaPathOut/dataPathOut may be null.
+bool writeSegmentSigmf(const QString &dir,
+                       SampleSource<std::complex<float>> *src,
+                       size_t start, size_t count,
+                       double sampleRate, double centerFreq,
+                       QString *metaPathOut, QString *dataPathOut,
+                       QString *errorOut);
+
+// Parse an IQEngine-style { "annotations": [...] } blob into inspectrum Annotations,
+// mapping segment-local sample indices to absolute file indices (abs = segStart +
+// local; inclusive max = abs + count - 1). Frequency edges are absolute Hz and pass
+// through; when omitted, [passLo, passHi] (the tuner pass-band) is substituted.
+//
+// segCount is the number of samples in the extracted segment: returned indices are
+// validated and clamped against it, so a buggy or hostile plugin cannot produce an
+// out-of-range / inverted range or trigger an out-of-range double->size_t cast.
+// Annotations whose start falls outside the segment, or with count < 1, are skipped.
+// Returns the parsed annotations; on malformed JSON returns empty and sets *errorOut.
+std::vector<Annotation> parsePluginAnnotations(const QByteArray &json,
+                                               size_t segStart, size_t segCount,
+                                               double passLo, double passHi,
+                                               QString *errorOut);
+
+// Runs a plugin over an extracted segment as an async child process. One run at a
+// time per instance (running() guards). Emits finished() with mapped annotations or
+// failed() with a human-readable error; exactly one is emitted per run().
+class PluginRunner : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit PluginRunner(QObject *parent = nullptr);
+    ~PluginRunner() override;
+
+    // Extract [start,count) from src, write the temp segment, and launch the plugin.
+    // centerFreq/passLo/passHi are absolute Hz. customParams is forwarded verbatim as
+    // the context.json "custom_params" object. Errors before launch are reported via
+    // failed(). timeoutMs <= 0 disables the timeout.
+    void run(const PluginManifest &manifest,
+             std::shared_ptr<SampleSource<std::complex<float>>> src,
+             size_t start, size_t count,
+             double sampleRate, double centerFreq,
+             double passLo, double passHi,
+             const QJsonObject &customParams,
+             int timeoutMs = 120000);
+
+    bool running() const { return running_; }
+
+public slots:
+    // Kill the process if running; no signal is emitted for a user cancel.
+    void cancel();
+
+signals:
+    void finished(std::vector<Annotation> annotations);
+    void failed(QString error);
+
+private slots:
+    void onProcFinished(int exitCode, int exitStatus);
+    void onProcErrorOccurred();
+    void onTimeout();
+
+private:
+    void cleanup();
+    void fail(const QString &error);
+
+    QProcess *proc_ = nullptr;
+    QTimer *timeoutTimer_ = nullptr;
+    std::unique_ptr<QTemporaryDir> tmpDir_;
+    bool running_ = false;
+    size_t segStart_ = 0;
+    size_t segCount_ = 0;
+    double passLo_ = 0.0;
+    double passHi_ = 0.0;
+};

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -136,11 +136,10 @@ public:
              const QJsonObject &customParams,
              int timeoutMs = 120000);
 
-    // running_ alone goes false the instant cancel() is called, but during an
-    // extraction cancel the worker thread is still alive until onExtractFinished()
-    // joins it. busy() stays true across that window so callers (and run()'s own
-    // single-flight guard) can't start a new run and stomp the in-flight one.
-    bool running() const { return running_; }
+    // busy() (not running_) is the single-flight guard: running_ goes false the
+    // instant cancel() is called, but during an extraction cancel the worker thread
+    // is still alive until onExtractFinished() joins it. busy() stays true across
+    // that window so callers can't start a new run and stomp the in-flight one.
     bool busy() const { return running_ || canceling_; }
 
 public slots:

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -20,11 +20,14 @@
 #pragma once
 
 #include <QObject>
+#include <QByteArray>
+#include <QFutureWatcher>
 #include <QString>
 #include <QStringList>
 #include <QVector>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <atomic>
 #include <complex>
 #include <memory>
 #include <vector>
@@ -33,6 +36,14 @@
 class QProcess;
 class QTimer;
 class QTemporaryDir;
+
+// Result of the (worker-thread) segment extraction.
+struct SegmentExtract {
+    bool ok = false;
+    bool canceled = false;
+    QString metaPath;
+    QString error;
+};
 
 // One declared parameter of a plugin (drives the auto-generated param dialog).
 struct PluginParam {
@@ -75,13 +86,16 @@ QVector<PluginManifest> discoverPlugins();
 // Write a temporary SigMF segment (cf32_le .sigmf-data + .sigmf-meta) for samples
 // [start, start+count) pulled from `src`. The meta carries core:sample_rate and
 // captures[0].core:frequency = centerFreq (absolute Hz). Returns false + *errorOut
-// on failure. metaPathOut/dataPathOut may be null.
+// on failure. metaPathOut/dataPathOut may be null. Safe to call off the GUI thread.
+// If `cancel` is non-null and becomes true, the write aborts between chunks,
+// removes the partial data file, and returns false with *errorOut == "canceled".
 bool writeSegmentSigmf(const QString &dir,
                        SampleSource<std::complex<float>> *src,
                        size_t start, size_t count,
                        double sampleRate, double centerFreq,
                        QString *metaPathOut, QString *dataPathOut,
-                       QString *errorOut);
+                       QString *errorOut,
+                       const std::atomic<bool> *cancel = nullptr);
 
 // Parse an IQEngine-style { "annotations": [...] } blob into inspectrum Annotations,
 // mapping segment-local sample indices to absolute file indices (abs = segStart +
@@ -132,20 +146,36 @@ signals:
     void failed(QString error);
 
 private slots:
+    void onExtractFinished();
     void onProcFinished(int exitCode, int exitStatus);
     void onProcErrorOccurred();
+    void onReadyStdout();
+    void onReadyStderr();
     void onTimeout();
 
 private:
     void cleanup();
     void fail(const QString &error);
+    void launchProcess(const QString &metaPath);
 
     QProcess *proc_ = nullptr;
     QTimer *timeoutTimer_ = nullptr;
     std::unique_ptr<QTemporaryDir> tmpDir_;
+    QFutureWatcher<SegmentExtract> *extractWatcher_ = nullptr;
+    std::atomic<bool> extractCancel_{false};
     bool running_ = false;
+    bool canceling_ = false;      // cancel requested while extraction is in flight
+    int timeoutMs_ = 0;
     size_t segStart_ = 0;
     size_t segCount_ = 0;
     double passLo_ = 0.0;
     double passHi_ = 0.0;
+    // Stashed at run() time; used to launch the process once extraction completes.
+    QString exec_;
+    QStringList args_;
+    QByteArray contextJson_;
+    // Incrementally accumulated child output, capped so a runaway plugin can't
+    // exhaust the GUI process's memory.
+    QByteArray outBuf_;
+    QByteArray errBuf_;
 };

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -135,7 +135,12 @@ public:
              const QJsonObject &customParams,
              int timeoutMs = 120000);
 
+    // running_ alone goes false the instant cancel() is called, but during an
+    // extraction cancel the worker thread is still alive until onExtractFinished()
+    // joins it. busy() stays true across that window so callers (and run()'s own
+    // single-flight guard) can't start a new run and stomp the in-flight one.
     bool running() const { return running_; }
+    bool busy() const { return running_ || canceling_; }
 
 public slots:
     // Kill the process if running; no signal is emitted for a user cancel.

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -113,8 +113,9 @@ std::vector<Annotation> parsePluginAnnotations(const QByteArray &json,
                                                QString *errorOut);
 
 // Runs a plugin over an extracted segment as an async child process. One run at a
-// time per instance (running() guards). Emits finished() with mapped annotations or
-// failed() with a human-readable error; exactly one is emitted per run().
+// time per instance (busy() guards — stays true across a cancelled extraction until
+// its worker is joined). Emits finished() with mapped annotations or failed() with a
+// human-readable error; exactly one is emitted per run(), and neither on cancel.
 class PluginRunner : public QObject
 {
     Q_OBJECT

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -193,6 +193,26 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     annoColorCheckBox = new QCheckBox(widget);
     layout->addRow(new QLabel(tr("Annotation Colors:")), annoColorCheckBox);
 
+    // Editable global file metadata (SigMF global core:description + a
+    // non-standard inspectrum:title). Saved via the same Save annotations path.
+    fileTitleEdit = new QLineEdit(widget);
+    fileTitleEdit->setToolTip(tr(
+        "Short title for the whole capture. Stored as a non-standard "
+        "inspectrum:title in the SigMF global object (other tools ignore it)."));
+    layout->addRow(new QLabel(tr("File title:")), fileTitleEdit);
+    connect(fileTitleEdit, &QLineEdit::editingFinished, this, [this]() {
+        emit fileTitleChanged(fileTitleEdit->text());
+    });
+
+    fileDescriptionEdit = new QLineEdit(widget);
+    fileDescriptionEdit->setToolTip(tr(
+        "Free-text note for the whole capture. Stored as the standard SigMF "
+        "global core:description."));
+    layout->addRow(new QLabel(tr("File description:")), fileDescriptionEdit);
+    connect(fileDescriptionEdit, &QLineEdit::editingFinished, this, [this]() {
+        emit fileDescriptionChanged(fileDescriptionEdit->text());
+    });
+
     saveAnnotationsButton = new QPushButton(tr("Save annotations"), widget);
     saveAnnotationsButton->setEnabled(false);
     saveAnnotationsButton->setToolTip(tr(
@@ -579,6 +599,14 @@ void SpectrogramControls::setAnnotationsDirty(bool dirty)
 {
     saveAnnotationsButton->setEnabled(dirty);
     saveAnnotationsButton->setText(dirty ? tr("Save annotations *") : tr("Save annotations"));
+}
+
+void SpectrogramControls::setFileInfo(const QString &title, const QString &description)
+{
+    // setText doesn't emit editingFinished, so this won't loop back through
+    // fileTitleChanged / fileDescriptionChanged.
+    fileTitleEdit->setText(title);
+    fileDescriptionEdit->setText(description);
 }
 
 void SpectrogramControls::applyAutoLpf(double cutoffHz, int predemodM, int postN)

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -20,6 +20,7 @@
 
 #include "spectrogramcontrols.h"
 #include <QIntValidator>
+#include <QDoubleSpinBox>
 #include <QFileDialog>
 #include <QHBoxLayout>
 #include <QSettings>
@@ -308,6 +309,34 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     layout->addRow(new QLabel(tr("FM squelch:")), fmSquelchSpinBox);
     connect(fmSquelchSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this, &SpectrogramControls::fmSquelchChanged);
+
+    // AM amplitude scale: linear power (default) vs a logarithmic dB scale.
+    // In dB the trace reads dBFS, or calibrated dBm once a full-scale
+    // reference is supplied below (the file carries no power calibration, so
+    // dBm needs the receiver's reference level entered by hand).
+    amDbCheckBox = new QCheckBox(widget);
+    amDbCheckBox->setChecked(false);
+    amDbCheckBox->setToolTip(tr(
+        "Show the AM (amplitude) plot on a dB scale instead of linear power. "
+        "Reads dBFS (dB below full scale); set a full-scale reference below to "
+        "read calibrated dBm."));
+    layout->addRow(new QLabel(tr("AM scale dB:")), amDbCheckBox);
+    connect(amDbCheckBox, &QCheckBox::toggled,
+            this, &SpectrogramControls::amDbModeChanged);
+
+    amRefLevelSpinBox = new QDoubleSpinBox(widget);
+    amRefLevelSpinBox->setRange(-200.0, 200.0);
+    amRefLevelSpinBox->setDecimals(1);
+    amRefLevelSpinBox->setSingleStep(1.0);
+    amRefLevelSpinBox->setValue(0.0);
+    amRefLevelSpinBox->setSuffix(" dBm");
+    amRefLevelSpinBox->setToolTip(tr(
+        "Power (dBm) corresponding to full scale (|IQ| = 1). Added to the AM "
+        "dB output so the plot reads true dBm — enter your receiver's "
+        "reference level. 0 leaves the scale as dBFS."));
+    layout->addRow(new QLabel(tr("AM full-scale ref:")), amRefLevelSpinBox);
+    connect(amRefLevelSpinBox, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+            this, &SpectrogramControls::amRefLevelChanged);
 
     // Auto-tune button: ask PlotView to pick reasonable values for cutoff,
     // predemod M, and post N. PlotView computes from current Fs and tuner

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -196,8 +196,11 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     saveAnnotationsButton = new QPushButton(tr("Save annotations"), widget);
     saveAnnotationsButton->setEnabled(false);
     saveAnnotationsButton->setToolTip(tr(
-        "Write the current annotation list to a .sigmf-meta sidecar next to "
-        "the data file. Becomes enabled after add/edit/delete."));
+        "Persist the current annotation list. For a .sigmf-meta/.sigmf-data "
+        "pair this rewrites the .sigmf-meta; for a SigMF archive (.sigmf / "
+        ".sigmf.zst) it appends an updated meta member (the data is not "
+        "recompressed) so the newest notes win on the next open. Becomes "
+        "enabled after add/edit/delete."));
     layout->addRow(saveAnnotationsButton);
     connect(saveAnnotationsButton, &QPushButton::clicked,
             this, &SpectrogramControls::saveAnnotationsRequested);

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -25,6 +25,7 @@
 #include <QPushButton>
 #include <QSlider>
 #include <QSpinBox>
+#include <QDoubleSpinBox>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLabel>
@@ -60,6 +61,10 @@ signals:
     void symbolRateChanged(double baud);
     // Amplitude squelch (% of window-peak |IQ|) for FM plots. 0 = off.
     void fmSquelchChanged(int pct);
+    // Toggle the AM plot between linear power and a dB scale.
+    void amDbModeChanged(bool on);
+    // Full-scale reference (dBm) added to AM plots in dB mode. 0 = dBFS.
+    void amRefLevelChanged(double dbm);
     // Signal-strength gate (% of window peak) for the FSK polar constellation.
     void constellationGateChanged(int pct);
     // Symbol-timed (1 point/symbol) vs full-rate FSK polar constellation.
@@ -178,6 +183,9 @@ public:
     QSpinBox   *fmPredemodDecimSpinBox;
     // FM amplitude squelch (% of window-peak |IQ|; 0 disables)
     QSpinBox   *fmSquelchSpinBox;
+    // AM dB-scale toggle and its full-scale reference (dBm; 0 = dBFS).
+    QCheckBox     *amDbCheckBox;
+    QDoubleSpinBox *amRefLevelSpinBox;
     // Auto-tune button: PlotView picks reasonable values for cutoff, M, N.
     QPushButton *fmAutoLpfButton;
     // Symbol rate (Bd) for the FSK polar plot, plus a button that copies the

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -91,6 +91,10 @@ signals:
     void reassignmentSplatChanged(int sm);
     // User clicked "Save annotations". MainWindow handles the actual write.
     void saveAnnotationsRequested();
+    // Edited the global file title / description. MainWindow forwards to the
+    // InputSource; persisted on the next save.
+    void fileTitleChanged(QString title);
+    void fileDescriptionChanged(QString description);
 
 public slots:
     void timeSelectionChanged(float time);
@@ -101,6 +105,9 @@ public slots:
     // button and tweaks its label so the user can see when there's pending
     // work without watching the title bar.
     void setAnnotationsDirty(bool dirty);
+    // Populate the global title / description fields (called on file open).
+    // Uses setText so it doesn't re-emit the *Changed signals.
+    void setFileInfo(const QString &title, const QString &description);
     void applyAutoLpf(double cutoffHz, int predemodM, int postN);
     // Show the auto-detected period (in seconds) of the visible FM trace.
     // periodSeconds <= 0 clears the label (no signal / not enough data).
@@ -199,4 +206,8 @@ public:
     // Save annotations to a .sigmf-meta sidecar. Shown disabled when the
     // annotation list hasn't been mutated since the last load/save.
     QPushButton *saveAnnotationsButton;
+    // Editable SigMF global metadata: title (inspectrum:title) + description
+    // (core:description).
+    QLineEdit *fileTitleEdit;
+    QLineEdit *fileDescriptionEdit;
 };

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -322,7 +322,31 @@ void SpectrogramPlot::paintAnnotations(QPainter &painter, QRect &rect, range_t<s
             }
             painter.drawRect(x, y, width, height);
 
-            visibleAnnotationLocations.emplace_back(a, x, y, width, height);
+            // Resize handles for the active (hovered / editing) annotation.
+            if (i == activeAnnotation_) {
+                const int hs = 3; // half handle size
+                const int xr = x + width, yb = y + height;
+                const int xm = x + width / 2, ym = y + height / 2;
+                painter.setPen(QPen(Qt::black, 1));
+                const int hx[] = { x, xm, xr, x, xr, x, xm, xr };
+                const int hy[] = { y, y,  y,  ym, ym, yb, yb, yb };
+                for (int k = 0; k < 8; ++k) {
+                    painter.fillRect(hx[k] - hs, hy[k] - hs, 2 * hs, 2 * hs, Qt::white);
+                    painter.drawRect(hx[k] - hs, hy[k] - hs, 2 * hs, 2 * hs);
+                }
+            }
+
+            // Hit rect for right-click / tooltip: pad by a few px and include
+            // the label drawn above the box so clicking the visible label (the
+            // natural target) still resolves to this annotation.
+            const int slop = 4;
+            int labelTop = sigmfAnnotationLabels ? (y - 2 - fm.ascent()) : y;
+            int labelW = sigmfAnnotationLabels ? fm.boundingRect(a.label).width() : 0;
+            int hitX = x - slop;
+            int hitY = std::min(y, labelTop) - slop;
+            int hitW = std::max(width, labelW) + 2 * slop;
+            int hitH = (y + height) - hitY + slop;
+            visibleAnnotationLocations.emplace_back(a, hitX, hitY, hitW, hitH);
         }
     }
 
@@ -374,6 +398,13 @@ double SpectrogramPlot::freqAtPlotY(int y) const
     if (height() <= 0 || sampleRate <= 0.0) return 0.0;
     const double offset = ((double)height() * 0.5 - (double)y) * sampleRate / (double)height();
     return inputSource->getFrequency() + offset;
+}
+
+int SpectrogramPlot::plotYAtFreq(double hz) const
+{
+    if (height() <= 0 || sampleRate <= 0.0) return 0;
+    const double offset = hz - inputSource->getFrequency();
+    return (int)std::lround((double)height() * 0.5 - offset * (double)height() / sampleRate);
 }
 
 void SpectrogramPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -81,8 +81,10 @@ void SpectrogramPlot::invalidateEvent()
 
 void SpectrogramPlot::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
-    if (tunerEnabled())
+    if (tunerEnabled()) {
         tuner.paintFront(painter, rect, sampleRange);
+        paintTunerReadout(painter, rect);
+    }
 
     if (frequencyScaleEnabled)
         paintFrequencyScale(painter, rect);
@@ -199,6 +201,79 @@ void SpectrogramPlot::paintFrequencyScale(QPainter &painter, QRect &rect)
 
             tick += bwPerTick;
         }
+    }
+    painter.restore();
+}
+
+void SpectrogramPlot::paintTunerReadout(QPainter &painter, QRect &rect)
+{
+    // Without a sample rate the pixel→Hz mapping is meaningless, so just leave
+    // the band un-annotated (the highlight itself still shows the width).
+    if (sampleRate <= 0.0)
+        return;
+
+    const double bw = tunerBandwidthHz();
+    const double offset = tunerOffsetHz();
+    const double centreFrequency = inputSource->getFrequency();
+    const bool haveAbsolute = centreFrequency != 0.0;
+
+    // Signed baseband-offset string, e.g. "+15 kHz" / "-3.2 kHz".
+    auto signedOffset = [](double hz) {
+        QString s = formatFrequencyLabel(fabs(hz), false);
+        s.prepend(hz < 0.0 ? QChar('-') : QChar('+'));
+        return s;
+    };
+
+    std::vector<QString> lines;
+    lines.push_back(QStringLiteral("BW ") + formatFrequencyLabel(bw, false));
+    if (haveAbsolute) {
+        // Absolute centre, with the tuning offset from capture DC in parens.
+        lines.push_back(formatFrequencyLabel(centreFrequency + offset, false)
+                        + QStringLiteral(" (") + signedOffset(offset)
+                        + QStringLiteral(")"));
+    } else {
+        // No absolute frequency known — the offset from capture DC is the only
+        // meaningful centre reference.
+        lines.push_back(signedOffset(offset));
+    }
+
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    QFontMetrics fm(painter.font());
+
+    const int padX = 6;
+    const int padY = 4;
+    const int lineH = fm.height();
+    int textW = 0;
+    for (const auto &l : lines)
+        textW = std::max(textW, fm.boundingRect(l).width());
+    const int boxW = textW + 2 * padX;
+    const int boxH = lineH * static_cast<int>(lines.size()) + 2 * padY;
+
+    // Anchor to the centre (red) cursor line and right-align within the plot so
+    // the pill never collides with the left-edge frequency scale. Clamp
+    // vertically so it stays fully on-screen when the tuner is near an edge.
+    const int margin = 8;
+    int boxX = rect.right() - margin - boxW;
+    if (boxX < rect.left() + margin)
+        boxX = rect.left() + margin;
+    const int centreY = rect.top() + tuner.centre();
+    int boxY = centreY - boxH / 2;
+    if (boxY < rect.top() + 2)
+        boxY = rect.top() + 2;
+    if (boxY + boxH > rect.bottom() - 2)
+        boxY = rect.bottom() - 2 - boxH;
+
+    QRect box(boxX, boxY, boxW, boxH);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor(0, 0, 0, 160));
+    painter.drawRoundedRect(box, 4, 4);
+
+    painter.setPen(Qt::white);
+    int ty = boxY + padY + fm.ascent();
+    for (const auto &l : lines) {
+        painter.drawText(boxX + padX, ty, l);
+        ty += lineH;
     }
     painter.restore();
 }

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -116,6 +116,11 @@ public:
     // Convert a y in plot-local coords (0..height()) to absolute Hz, using the
     // input source's centre frequency.
     double freqAtPlotY(int y) const;
+    // Inverse of freqAtPlotY: plot-local y (0..height()) for an absolute Hz.
+    int plotYAtFreq(double hz) const;
+    // Index of the annotation to draw resize handles on (it's being hovered or
+    // edited in PlotView), or -1 for none. Purely a paint hint.
+    void setActiveAnnotation(int index) { activeAnnotation_ = index; }
 
 public slots:
     void setFFTSize(int size);
@@ -176,6 +181,9 @@ private:
     WindowType windowType = WindowType::Hann;
     // Splat method when accumulating reassigned energy.
     SplatMethod splatMethod = SplatMethod::Bilinear;
+    // Annotation index to draw resize handles on (-1 = none). Set by PlotView
+    // while hovering/editing an annotation; only affects paintAnnotations.
+    int activeAnnotation_ = -1;
 
     // Worker FFT plan + buffer pool for parallel reassigned tile compute.
     // Plans must be created on a single thread (FFTW planning isn't

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -238,6 +238,10 @@ private:
     std::vector<float> getTunerTaps();
     int linesPerTile();
     void paintFrequencyScale(QPainter &painter, QRect &rect);
+    // Live centre-frequency / pass-band-width readout drawn next to the tuner
+    // band while it's enabled, so dragging the tuner cursors shows the filter
+    // width (e.g. "BW 25 kHz") and centre frequency in Hz instead of pixels.
+    void paintTunerReadout(QPainter &painter, QRect &rect);
     void paintAnnotations(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
 };
 


### PR DESCRIPTION
## Summary

Adds a **plugin API** so inspectrum can hand a *filtered/tuned section* of a recording to an **external process** that analyses it and returns **annotations** (bursts, calls, sync words, …). Returned annotations appear in the normal annotation UI — editable (drag handles), dirty-tracked, and savable back to SigMF (sidecar or tar+zstd archive).

The signal handed to a plugin is the tuned/filtered IQ the derived plots see (the spectrogram `TunerTransform` output when the tuner is on, else the raw input), extracted over a chosen region.

## What's here

- **`src/plugin.{h,cpp}`** — manifest model + discovery (`~/.config/inspectrum/plugins/*.json`); temporary SigMF segment writer (`cf32_le`); an IQEngine-compatible annotation parser that maps segment-local sample indices to absolute file indices and **validates/clamps** them against the segment; and an async `QProcess` runner (busy dialog + cancel + timeout, single-flight).
- **`PlotView`** — right-click **Run plugin ▸** submenu, scope dialog (selection / view / whole), auto-generated per-plugin param dialog, ingestion of results.
- **`MainWindow`** — a **Tools → Run plugin** menu (the app's first menu bar) + **Reload plugins**.
- **`doc/plugins.md`** — plugin-author reference (manifest + wire protocol). `doc/plugin-api-plan.md` — design notes.
- **`examples/plugins/energy-detect.py`** — reference energy-gate burst detector (memmap-streamed, float32) + manifest.

## Wire protocol (IQEngine-schema over a CLI)

```
<exec> [args...] <segment.sigmf-meta>   # stdin = {sample_rate, center_freq, custom_params}, stdout = {"annotations":[...]}
```
Annotation `core:sample_start`/`core:sample_count` are segment-local; freq edges are absolute Hz (fall back to the tuner pass-band when omitted).

## Correctness notes

- `TunerTransform` is **1:1** (no decimation) → sample indices map by a pure offset (no `*M`).
- `Annotation::frequencyRange` is **absolute Hz**; `sampleRange` is absolute inclusive `[min,max]`.
- Plugin-returned indices are validated/clamped against the segment (no double→size_t UB, no overflow→inverted ranges).

## Testing

- Standalone harness: segment byte-layout/meta round-trip + coordinate map (abs start, inclusive max, freq passthrough, pass-band fallback, `#RRGGBBAA` colour rotation, clamp/validation) — all pass.
- End-to-end: reference plugin detects a synthetic burst exactly via its real CLI contract.
- Full app builds clean and launches (offscreen) with a manifest discovered.

## Note on scope

This branch also carries the 5 previously-developed local commits (tuner readout, AM dB/dBm, archive annotation persistence, annotation bounds editing, editable global metadata) that the plugin work builds on and that were not yet on `main`. Review focus is the plugin API (top commit `ba9263c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)