### PR TITLE
traceplot: fix aliased decimation; raw pre-tuner plots; selection cursors

### DIFF
--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -761,6 +761,31 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
         plotsMenu->addAction(action);
     }
 
+    // Plots derived from the raw (pre-tuner) input. The normal derived plots
+    // all sit behind the TunerTransform, so low-level detail like PA ramp-up
+    // is shaped by the tuner's FIR and its placement; these bypass that and
+    // show the untouched capture. Deliberately does not touch the tuner.
+    {
+        QMenu *rawMenu = menu.addMenu("Add raw plot (pre-filter)");
+        auto rawSrc = std::static_pointer_cast<AbstractSampleSource>(spectrogramPlot->input());
+        auto rawCompatible = as_range(Plots::plots.equal_range(rawSrc->sampleType()));
+        for (auto p : rawCompatible) {
+            auto plotInfo = p.second;
+            auto action = new QAction(QString("Add raw %1").arg(plotInfo.name), rawMenu);
+            auto plotCreator = plotInfo.creator;
+            connect(
+                action, &QAction::triggered,
+                this, [=]() {
+                    addPlot(plotCreator(rawSrc));
+                    this->zoomSample = clickSample;
+                    this->zoomPos = centerX;
+                    this->updateView(true);
+                }
+            );
+            rawMenu->addAction(action);
+        }
+    }
+
     // Add submenu for extracting symbols
     QMenu *extractMenu = menu.addMenu("Extract symbols");
     // Add action to extract symbols from selected plot to stdout

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -2222,13 +2222,21 @@ void PlotView::paintEvent(QPaintEvent *event)
     specPlot->paintMid(painter, specRect, viewRange);
     specPlot->paintFront(painter, specRect, viewRange);
 
-    // Draw cursors and time scale over spectrogram
+    // Draw cursors and time scale over spectrogram. specRect spans the whole
+    // scrollable spectrogram, which extends under the derived-plot band when
+    // specHeight exceeds the visible spectrogram area — clip so the highlight
+    // fill and segment ticks stop at the band and aren't composited twice by
+    // the mirrored pass below.
+    int specViewHeight = std::max(0, viewRect.height() - derivedHeight);
+    painter.save();
+    painter.setClipRect(QRect(0, 0, width(), specViewHeight));
     if (cursorsEnabled) {
         cursors.paintFront(painter, specRect, viewRange);
     }
     if (timeScaleEnabled) {
         paintTimeScale(painter, specRect, viewRange);
     }
+    painter.restore();
 
     // Draw derived plots in a fixed area at the bottom (always visible).
     // When the file ends before the viewport's right edge (zoomed-out short
@@ -2270,7 +2278,7 @@ void PlotView::paintEvent(QPaintEvent *event)
         // cursor positions are already in viewport coordinates, so the same
         // paint call works here with the derived area's rect.
         if (cursorsEnabled) {
-            QRect derivedRect(0, viewRect.height() - derivedHeight, width(), derivedHeight);
+            QRect derivedRect(0, viewRect.height() - derivedHeight, contentWidth, derivedHeight);
             cursors.paintFront(painter, derivedRect, viewRange);
         }
     }

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -691,8 +691,14 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
     // the click was in an existing derived plot, not the spectrogram).
     int tunerCentreY = -1;
     // Check if click is in derived plot area (fixed at bottom)
-    if (plots.size() > 1 && clickY >= viewportH - derivedPlotHeight) {
-        int posInDerived = clickY - (viewportH - derivedPlotHeight);
+    // The derived plots are a stack, so the band starts at the top of the
+    // whole stack — not one plot height up. Testing against a single height
+    // sent a right-click in any but the bottom plot down the spectrogram
+    // branch, which then moved the tuner to the clicked y. Matches the hit
+    // test in mouseMoveEvent.
+    const int derivedTotalH = int(plots.size() - 1) * derivedPlotHeight;
+    if (plots.size() > 1 && clickY >= viewportH - derivedTotalH) {
+        int posInDerived = clickY - (viewportH - derivedTotalH);
         plotIndex = 1 + posInDerived / derivedPlotHeight;
         if (plotIndex >= plots.size())
             return;

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -2264,6 +2264,15 @@ void PlotView::paintEvent(QPaintEvent *event)
             plot->paintFront(painter, rect, viewRange);
             y += plot->height();
         }
+
+        // Mirror the time-selection cursors over the derived-plot stack so the
+        // selected span lines up column-for-column with the spectrogram. The
+        // cursor positions are already in viewport coordinates, so the same
+        // paint call works here with the derived area's rect.
+        if (cursorsEnabled) {
+            QRect derivedRect(0, viewRect.height() - derivedHeight, width(), derivedHeight);
+            cursors.paintFront(painter, derivedRect, viewRange);
+        }
     }
     LatencyLog::mark("paintEvent end");
 }

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -334,6 +334,18 @@ void TracePlot::applyMinMax(QPair<double,double> result)
                              std::abs(newMax - globalMax) > tol;
     if (!significant) return;
 
+    // A cached render is only visibly wrong once the scale has moved a lot —
+    // most importantly on the very first scan, which replaces the default
+    // 0..1 with the signal's real range and would otherwise leave the trace
+    // slammed against the rails until the next pan or zoom minted a new key.
+    // 25% of range is far above the post-tuner-drag wobble the tolerance gate
+    // above already absorbs, so this re-renders when it matters and stays
+    // quiet when it doesn't.
+    const double scaleTol = std::max(1e-9, oldRange * 0.25);
+    if (std::abs(newMin - globalMin) > scaleTol ||
+        std::abs(newMax - globalMax) > scaleTol)
+        ++scaleEpoch;
+
     const double prevMin = globalMin, prevMax = globalMax;
     globalMin = newMin;
     globalMax = newMax;
@@ -396,7 +408,7 @@ void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleR
         const size_t start = sampleRange.minimum;
         const size_t len = sampleRange.maximum - sampleRange.minimum;
 
-        FloatKey k{start, len, w, h, yScale, dataEpoch};
+        FloatKey k{start, len, w, h, yScale, dataEpoch, scaleEpoch};
         floatPendingKey_ = k;
         floatPendingValid_ = true;
 
@@ -463,7 +475,7 @@ QPixmap TracePlot::getTile(size_t tileID, size_t sampleCount, int tileWidthPx)
     QString key;
     QTextStream ts(&key);
     ts << "traceplot_" << this << "_" << tileID << "_" << sampleCount
-       << "_" << dataEpoch;
+       << "_" << dataEpoch << "_" << scaleEpoch << "_" << height();
     currentFrameKeys.insert(key);
     // if we already have a cached pixmap, return it immediately
     if (QPixmapCache::find(key, &pixmap))
@@ -572,17 +584,34 @@ void TracePlot::plotTrace(QPainter &painter, const QRect &rect, float *samples,
     if (samplesPerPx <= maxPointsPerPixel) {
         const double xStep = double(w) / double(count);
         bool first = true;
+        size_t runLen = 0;
+        double lastX = 0.0, lastY = 0.0;
+        // A run of exactly one finite sample emits a lone moveTo, and a
+        // one-element subpath draws nothing — the same invisibility the
+        // envelope branch guards against. Squelch NaNs each sample
+        // independently, so alternating NaN/finite is a real input.
+        auto endRun = [&]() {
+            if (runLen == 1 && w >= 2) {
+                double stubX = (lastX + 1.0 <= rect.x() + w - 1) ? lastX + 1.0
+                                                                 : lastX - 1.0;
+                path.lineTo(stubX, lastY);
+            }
+            first = true;
+            runLen = 0;
+        };
         for (size_t i = 0; i < count; i++) {
             float s = samples[i * step];
             // Break the path at a non-finite sample, same as the envelope
             // branch below and renderFloatTrace: clip() would otherwise fold
             // NaN to the top of the plot and draw a full-height spike.
-            if (!std::isfinite(s)) { first = true; continue; }
+            if (!std::isfinite(s)) { endRun(); continue; }
             double x = xRange.clip(i * xStep) + rect.x();
             double y = yRange.clip(toY(s)) + rect.y();
             if (first) { path.moveTo(x, y); first = false; }
             else       { path.lineTo(x, y); }
+            lastX = x; lastY = y; runLen++;
         }
+        endRun();
     } else {
         bool first = true;
         for (int x = 0; x < w; x++) {
@@ -678,16 +707,31 @@ static QImage renderFloatTrace(SampleSource<float> *src,
 
     if (samplesPerPx <= maxPointsPerPixel) {
         const double xStep = double(w) / double(len);
+        size_t runLen = 0;
+        double lastX = 0.0, lastY = 0.0;
+        // Same one-element-subpath hazard as the envelope branch below: a lone
+        // finite sample between two squelch NaNs would otherwise draw nothing.
+        auto endRun = [&]() {
+            if (runLen == 1 && w >= 2) {
+                double stubX = (lastX + 1.0 <= w - 1) ? lastX + 1.0 : lastX - 1.0;
+                path.lineTo(stubX, lastY);
+            }
+            first = true;
+            runLen = 0;
+        };
         for (size_t i = 0; i < len; i++) {
             double s = samples[i];
             // Break the path at a non-finite sample (squelch / cold-start gap)
             // so the next finite point starts a fresh subpath instead of
             // bridging the gap with a straight line.
-            if (!std::isfinite(s)) { first = true; continue; }
+            if (!std::isfinite(s)) { endRun(); continue; }
             double y = toY(s);
-            if (first) { path.moveTo(i * xStep, y); first = false; }
-            else       { path.lineTo(i * xStep, y); }
+            double x = i * xStep;
+            if (first) { path.moveTo(x, y); first = false; }
+            else       { path.lineTo(x, y); }
+            lastX = x; lastY = y; runLen++;
         }
+        endRun();
     } else {
         for (int x = 0; x < w; x++) {
             const size_t begin = size_t(x) * len / w;
@@ -704,8 +748,13 @@ static QImage renderFloatTrace(SampleSource<float> *src,
             double yTop = toY(hi);
             double yBot = toY(lo);
             // Single-sample column: a zero-length subpath draws nothing, so an
-            // isolated burst after a squelch gap would be invisible.
-            if (yBot - yTop < 1.0) yBot = yTop + 1.0;
+            // isolated burst after a squelch gap would be invisible. toY only
+            // clamps to [0, h], so pull yTop up first or a burst sitting at the
+            // bottom of the range extends past the last row and draws faint.
+            if (yBot - yTop < 1.0) {
+                yTop = std::min(yTop, double(h) - 1.0);
+                yBot = yTop + 1.0;
+            }
             if (first) { path.moveTo(x, yTop); first = false; }
             else       { path.lineTo(x, yTop); }
             path.lineTo(x, yBot);

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -483,7 +483,7 @@ QPixmap TracePlot::getTile(size_t tileID, size_t sampleCount, int tileWidthPx)
 
     // schedule a new tile-draw if not already running or pending
     if (!tasks.contains(key) && !pendingInfo.contains(key)) {
-        pendingInfo.insert(key, {tileID, sampleCount, tileWidthPx});
+        pendingInfo.insert(key, {tileID, sampleCount, tileWidthPx, height()});
         debounceTimer->start();
     }
     pixmap.fill(Qt::transparent);
@@ -652,6 +652,7 @@ void TracePlot::schedulePendingTiles()
         size_t tileID = it.value().tileID;
         size_t sampleCount = it.value().sampleCount;
         int tilePx = it.value().tileWidth;
+        int tileH = it.value().tileHeight;
         range_t<size_t> sampleRange{ tileID * sampleCount,
                                     (tileID + 1) * sampleCount };
         // launch background draw (rect size uses tilePx)
@@ -659,7 +660,7 @@ void TracePlot::schedulePendingTiles()
         double maxv = globalMax;
         if (maxv <= minv) maxv = minv + 1.0;
         QtConcurrent::run(this, &TracePlot::drawTile,
-                         key, QRect(0, 0, tilePx, height()), sampleRange,
+                         key, QRect(0, 0, tilePx, tileH), sampleRange,
                          0.5 * (minv + maxv), 1.0 / (maxv - minv));
         tasks.insert(key);
     }
@@ -802,7 +803,12 @@ void TracePlot::onFloatImageReady()
         double maxv = globalMax;
         if (maxv <= minv) maxv = minv + 1.0;
         double mid = 0.5 * (minv + maxv);
-        double invRange = yScale / (maxv - minv);
+        // Scale from the key we are about to render, not from the live member.
+        // dataEpoch and scaleEpoch are monotonic, so a mismatch there can only
+        // produce an image keyed to a generation that is never minted again —
+        // but yScale is not, so reading it live would cache a wheel-zoomed
+        // image under the pre-zoom key and blit it back when the user returns.
+        double invRange = floatPendingKey_.yScale / (maxv - minv);
         startFloatRender(floatPendingKey_, mid, invRange);
     }
     emit repaint();

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -549,7 +549,11 @@ void TracePlot::plotTrace(QPainter &painter, const QRect &rect, float *samples,
     const int w = rect.width();
     const int h = rect.height();
     if (w < 1 || h < 1 || count == 0) return;
-    range_t<float> xRange{0.f, float(w - 2)};
+    // Clip x to the last drawable column, not w-2: now that the dense branch
+    // emits every sample rather than one per column, a tighter bound piles the
+    // tile's trailing samples onto a single x and draws a phantom min/max bar
+    // at every tile boundary.
+    range_t<float> xRange{0.f, float(w - 1)};
     range_t<float> yRange{0.f, float(h - 2)};
 
     auto toY = [&](float s) {
@@ -569,8 +573,13 @@ void TracePlot::plotTrace(QPainter &painter, const QRect &rect, float *samples,
         const double xStep = double(w) / double(count);
         bool first = true;
         for (size_t i = 0; i < count; i++) {
+            float s = samples[i * step];
+            // Break the path at a non-finite sample, same as the envelope
+            // branch below and renderFloatTrace: clip() would otherwise fold
+            // NaN to the top of the plot and draw a full-height spike.
+            if (!std::isfinite(s)) { first = true; continue; }
             double x = xRange.clip(i * xStep) + rect.x();
-            double y = yRange.clip(toY(samples[i * step])) + rect.y();
+            double y = yRange.clip(toY(s)) + rect.y();
             if (first) { path.moveTo(x, y); first = false; }
             else       { path.lineTo(x, y); }
         }
@@ -591,6 +600,10 @@ void TracePlot::plotTrace(QPainter &painter, const QRect &rect, float *samples,
             double xr = xRange.clip(float(x)) + rect.x();
             double yTop = yRange.clip(toY(hi)) + rect.y();
             double yBot = yRange.clip(toY(lo)) + rect.y();
+            // A column holding a single sample gives yTop == yBot. Starting a
+            // subpath with a zero-length line draws nothing under a flat cap,
+            // so isolated bursts after a gap would vanish — give it 1px.
+            if (yBot - yTop < 1.0) yBot = yTop + 1.0;
             if (first) { path.moveTo(xr, yTop); first = false; }
             else       { path.lineTo(xr, yTop); }
             path.lineTo(xr, yBot);
@@ -690,6 +703,9 @@ static QImage renderFloatTrace(SampleSource<float> *src,
             if (lo > hi) { first = true; continue; }  // all-gap column
             double yTop = toY(hi);
             double yBot = toY(lo);
+            // Single-sample column: a zero-length subpath draws nothing, so an
+            // isolated burst after a squelch gap would be invisible.
+            if (yBot - yTop < 1.0) yBot = yTop + 1.0;
             if (first) { path.moveTo(x, yTop); first = false; }
             else       { path.lineTo(x, yTop); }
             path.lineTo(x, yBot);

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -328,23 +328,22 @@ void TracePlot::applyMinMax(QPair<double,double> result)
     // tall plot would shift by <2 px), so reject sub-tolerance updates and
     // leave globalMin/Max unchanged so the axis labels match the cached
     // image's mapping exactly.
-    const double oldRange = std::max(globalMax - globalMin, 1.0);
-    const double tol = std::max(1e-9, oldRange * 0.01);
+    // Gauge the tolerance off the larger of the old and new ranges, not off a
+    // range floored at 1.0: for a capture peaking at 0.02 a floored range made
+    // tol 0.01, half the signal's entire span, so a 40%-visible rescale was
+    // rejected outright and the plot stayed frozen at the wrong scale.
+    const double refRange = std::max({globalMax - globalMin, newMax - newMin, 1e-12});
+    const double tol = std::max(1e-12, refRange * 0.01);
     const bool significant = std::abs(newMin - globalMin) > tol ||
                              std::abs(newMax - globalMax) > tol;
     if (!significant) return;
 
-    // A cached render is only visibly wrong once the scale has moved a lot —
-    // most importantly on the very first scan, which replaces the default
-    // 0..1 with the signal's real range and would otherwise leave the trace
-    // slammed against the rails until the next pan or zoom minted a new key.
-    // 25% of range is far above the post-tuner-drag wobble the tolerance gate
-    // above already absorbs, so this re-renders when it matters and stays
-    // quiet when it doesn't.
-    const double scaleTol = std::max(1e-9, oldRange * 0.25);
-    if (std::abs(newMin - globalMin) > scaleTol ||
-        std::abs(newMax - globalMax) > scaleTol)
-        ++scaleEpoch;
+    // Invalidate the cached renders on exactly the same condition that moves
+    // globalMin/Max. A second, coarser threshold here would open a band where
+    // the axis labels paintFront draws live have moved but the cached pixels
+    // still encode the old mapping — permanently, since nothing else mints a
+    // new key. The gate above is already the churn filter.
+    ++scaleEpoch;
 
     const double prevMin = globalMin, prevMax = globalMax;
     globalMin = newMin;
@@ -475,7 +474,8 @@ QPixmap TracePlot::getTile(size_t tileID, size_t sampleCount, int tileWidthPx)
     QString key;
     QTextStream ts(&key);
     ts << "traceplot_" << this << "_" << tileID << "_" << sampleCount
-       << "_" << dataEpoch << "_" << scaleEpoch << "_" << height();
+       << "_" << dataEpoch << "_" << scaleEpoch << "_" << height()
+       << "_" << tileWidthPx;
     currentFrameKeys.insert(key);
     // if we already have a cached pixmap, return it immediately
     if (QPixmapCache::find(key, &pixmap))
@@ -490,7 +490,8 @@ QPixmap TracePlot::getTile(size_t tileID, size_t sampleCount, int tileWidthPx)
     return pixmap;
 }
 
-void TracePlot::drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange)
+void TracePlot::drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange,
+                         double mid, double invRange)
 {
     // NOTE: runs on a QtConcurrent worker thread. Do not touch currentFrameKeys
     // or tasks from here — they live on the GUI thread and QSet isn't
@@ -506,12 +507,11 @@ void TracePlot::drawTile(QString key, const QRect &rect, range_t<size_t> sampleR
     auto firstSample = sampleRange.minimum;
     auto length = sampleRange.length();
 
-    // Snapshot the shared global range so every tile renders at the same scale.
-    double minv = globalMin;
-    double maxv = globalMax;
-    if (maxv <= minv) maxv = minv + 1.0;
-    double mid = 0.5 * (minv + maxv);
-    double invRange = 1.0 / (maxv - minv);
+    // mid/invRange are snapshotted on the GUI thread at dispatch (see
+    // schedulePendingTiles). Reading globalMin/Max here instead would be a
+    // data race against applyMinMax, and would let a scan landing mid-flight
+    // give one frame's tiles two different scales — cached under keys minted
+    // before the bump, so the amplitude step at the tile seam never clears.
 
     // Is it a 2-channel (complex) trace?
     if (auto src = dynamic_cast<SampleSource<std::complex<float>>*>(sampleSource.get())) {
@@ -655,8 +655,12 @@ void TracePlot::schedulePendingTiles()
         range_t<size_t> sampleRange{ tileID * sampleCount,
                                     (tileID + 1) * sampleCount };
         // launch background draw (rect size uses tilePx)
+        double minv = globalMin;
+        double maxv = globalMax;
+        if (maxv <= minv) maxv = minv + 1.0;
         QtConcurrent::run(this, &TracePlot::drawTile,
-                         key, QRect(0, 0, tilePx, height()), sampleRange);
+                         key, QRect(0, 0, tilePx, height()), sampleRange,
+                         0.5 * (minv + maxv), 1.0 / (maxv - minv));
         tasks.insert(key);
     }
 }

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -544,49 +544,57 @@ void TracePlot::handleImage(QString key, QImage image)
 void TracePlot::plotTrace(QPainter &painter, const QRect &rect, float *samples,
                           size_t count, int step, double mid, double invRange)
 {
-    // Build a path by down-sampling to at most one point per pixel column.
     // Scaling (mid, invRange) is supplied by the caller so all tiles share one range.
     QPainterPath path;
     const int w = rect.width();
     const int h = rect.height();
+    if (w < 1 || h < 1 || count == 0) return;
     range_t<float> xRange{0.f, float(w - 2)};
     range_t<float> yRange{0.f, float(h - 2)};
 
-    // Compute x-step per sample
-    const double xStep = double(w) / double(count);
-    // Down-sample: at most one point per pixel
-    size_t decim = 1;
-    if (size_t(w) < count)
-        decim = (count + w - 1) / w;  // ceil(count/w)
-
-    bool first = true;
-    // Plot samples at intervals of decim
-    for (size_t i = 0; i < count; i += decim) {
-        float s = samples[i * step];
+    auto toY = [&](float s) {
         double norm = (s - mid) * invRange;
-        double x = i * xStep;
-        double y = (1.0 - norm) * (h * 0.5);
+        return (1.0 - norm) * (h * 0.5);
+    };
 
-        x = xRange.clip(x) + rect.x();
-        y = yRange.clip(y) + rect.y();
+    // Picking one sample per pixel column aliases: any component faster than
+    // the pixel rate (an IQ carrier at a few px/cycle) folds down and renders
+    // as a slow, clean-looking waveform. Up to a few samples per pixel we can
+    // afford to draw every sample; denser than that no line plot can show the
+    // waveform anyway, so draw an honest per-column min/max envelope instead.
+    static const size_t maxPointsPerPixel = 16;
+    const size_t samplesPerPx = (count + w - 1) / w;
 
-        if (first) {
-            path.moveTo(x, y);
-            first = false;
-        } else {
-            path.lineTo(x, y);
+    if (samplesPerPx <= maxPointsPerPixel) {
+        const double xStep = double(w) / double(count);
+        bool first = true;
+        for (size_t i = 0; i < count; i++) {
+            double x = xRange.clip(i * xStep) + rect.x();
+            double y = yRange.clip(toY(samples[i * step])) + rect.y();
+            if (first) { path.moveTo(x, y); first = false; }
+            else       { path.lineTo(x, y); }
         }
-    }
-    // Ensure last sample is included
-    if (count > 0 && (count - 1) % decim != 0) {
-        float s = samples[(count - 1) * step];
-        double norm = (s - mid) * invRange;
-        double x = double(w - 1);
-        double y = (1.0 - norm) * (h * 0.5);
-
-        x = xRange.clip(x) + rect.x();
-        y = yRange.clip(y) + rect.y();
-        path.lineTo(x, y);
+    } else {
+        bool first = true;
+        for (int x = 0; x < w; x++) {
+            const size_t begin = size_t(x) * count / w;
+            const size_t end = std::min(count, size_t(x + 1) * count / w);
+            float lo = std::numeric_limits<float>::infinity();
+            float hi = -std::numeric_limits<float>::infinity();
+            for (size_t i = begin; i < end; i++) {
+                float s = samples[i * step];
+                if (!std::isfinite(s)) continue;
+                lo = std::min(lo, s);
+                hi = std::max(hi, s);
+            }
+            if (lo > hi) { first = true; continue; }  // no finite samples: gap
+            double xr = xRange.clip(float(x)) + rect.x();
+            double yTop = yRange.clip(toY(hi)) + rect.y();
+            double yBot = yRange.clip(toY(lo)) + rect.y();
+            if (first) { path.moveTo(xr, yTop); first = false; }
+            else       { path.lineTo(xr, yTop); }
+            path.lineTo(xr, yBot);
+        }
     }
     painter.drawPath(path);
 }
@@ -641,26 +649,51 @@ static QImage renderFloatTrace(SampleSource<float> *src,
 
     QPainterPath path;
     bool first = true;
-    const double xStep = double(w) / double(len);
-    const size_t decim = (len > size_t(w)) ? (len + w - 1) / w : 1;
-    auto addPoint = [&](size_t i, double xCoord) {
-        double s = samples[i];
-        // Break the path at a non-finite sample (squelch / cold-start gap) so
-        // the next finite point starts a fresh subpath instead of bridging the
-        // gap with a straight line.
-        if (!std::isfinite(s)) { first = true; return; }
+    auto toY = [&](double s) {
         double norm = (s - mid) * invRange;
         if (norm >  1.0) norm =  1.0;
         if (norm < -1.0) norm = -1.0;
-        double y = (1.0 - norm) * (h * 0.5);
-        if (first) { path.moveTo(xCoord, y); first = false; }
-        else       { path.lineTo(xCoord, y); }
+        return (1.0 - norm) * (h * 0.5);
     };
-    for (size_t i = 0; i < len; i += decim) {
-        addPoint(i, i * xStep);
-    }
-    if (len > 0 && (len - 1) % decim != 0) {
-        addPoint(len - 1, w - 1);
+
+    // Same aliasing guard as TracePlot::plotTrace: draw every sample while
+    // that stays affordable, else an honest per-column min/max envelope —
+    // never single-sample decimation, which folds fast components down into
+    // convincing-looking low-frequency artefacts.
+    static const size_t maxPointsPerPixel = 16;
+    const size_t samplesPerPx = (len + w - 1) / w;
+
+    if (samplesPerPx <= maxPointsPerPixel) {
+        const double xStep = double(w) / double(len);
+        for (size_t i = 0; i < len; i++) {
+            double s = samples[i];
+            // Break the path at a non-finite sample (squelch / cold-start gap)
+            // so the next finite point starts a fresh subpath instead of
+            // bridging the gap with a straight line.
+            if (!std::isfinite(s)) { first = true; continue; }
+            double y = toY(s);
+            if (first) { path.moveTo(i * xStep, y); first = false; }
+            else       { path.lineTo(i * xStep, y); }
+        }
+    } else {
+        for (int x = 0; x < w; x++) {
+            const size_t begin = size_t(x) * len / w;
+            const size_t end = std::min(len, size_t(x + 1) * len / w);
+            double lo = std::numeric_limits<double>::infinity();
+            double hi = -std::numeric_limits<double>::infinity();
+            for (size_t i = begin; i < end; i++) {
+                double s = samples[i];
+                if (!std::isfinite(s)) continue;
+                lo = std::min(lo, s);
+                hi = std::max(hi, s);
+            }
+            if (lo > hi) { first = true; continue; }  // all-gap column
+            double yTop = toY(hi);
+            double yBot = toY(lo);
+            if (first) { path.moveTo(x, yTop); first = false; }
+            else       { path.lineTo(x, yTop); }
+            path.lineTo(x, yBot);
+        }
     }
     painter.drawPath(path);
     return image;

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -105,6 +105,13 @@ private:
     // used to drive the LatencyLog message; could be repurposed if the
     // axis layer ever wants to debounce its own redraw on it.
     int minMaxEpoch = 0;
+    // Bumped only when globalMin/Max move enough to make a cached render
+    // visibly wrong (see applyMinMax). Part of both cache keys, so the very
+    // first frame — dispatched against the default 0..1 before the async scan
+    // has landed — is re-rendered once the real range arrives, while the
+    // small post-tuner-drag wobble that minMaxEpoch tracks does not churn the
+    // cache. Axis labels are drawn live from globalMin/Max either way.
+    int scaleEpoch = 0;
     // Width of each tile in pixels
     // default tile width in pixels (fallback)
     const int defaultTileWidth = 1000;
@@ -129,9 +136,10 @@ private:
         int      h     = 0;
         double   yScale = 1.0;
         int      epoch = 0;   // mirrors TracePlot::dataEpoch
+        int      scale = 0;   // mirrors TracePlot::scaleEpoch
         bool operator==(const FloatKey &o) const {
             return start==o.start && len==o.len && w==o.w && h==o.h
-                && yScale==o.yScale && epoch==o.epoch;
+                && yScale==o.yScale && epoch==o.epoch && scale==o.scale;
         }
         bool operator!=(const FloatKey &o) const { return !(*this == o); }
     };

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -105,12 +105,13 @@ private:
     // used to drive the LatencyLog message; could be repurposed if the
     // axis layer ever wants to debounce its own redraw on it.
     int minMaxEpoch = 0;
-    // Bumped only when globalMin/Max move enough to make a cached render
-    // visibly wrong (see applyMinMax). Part of both cache keys, so the very
-    // first frame — dispatched against the default 0..1 before the async scan
-    // has landed — is re-rendered once the real range arrives, while the
-    // small post-tuner-drag wobble that minMaxEpoch tracks does not churn the
-    // cache. Axis labels are drawn live from globalMin/Max either way.
+    // Bumped whenever applyMinMax actually moves globalMin/Max — i.e. on
+    // exactly the changes that get past its tolerance gate. Part of both
+    // cache keys, so a cached render can never encode a different mapping
+    // than the one paintFront is drawing axis labels from. Most visibly, the
+    // first frame is dispatched against the default 0..1 before the async
+    // scan lands; this is what re-renders it at the real range instead of
+    // leaving the trace slammed against the rails until the next pan.
     int scaleEpoch = 0;
     // Width of each tile in pixels
     // default tile width in pixels (fallback)
@@ -161,7 +162,8 @@ private:
     void startFloatRender(const FloatKey &k, double mid, double invRange);
     // Request the pixmap for a given tile (width in pixels drives sample count)
     QPixmap getTile(size_t tileID, size_t sampleCount, int tileWidthPx);
-    void drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange);
+    void drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange,
+                  double mid, double invRange);
     void plotTrace(QPainter &painter, const QRect &rect, float *samples,
                    size_t count, int step, double mid, double invRange);
 };

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -75,8 +75,13 @@ private slots:
 private:
     // In-process tile keys
     QSet<QString> tasks;
-    // Tiles waiting to be scheduled: key -> (tileID, sampleCount, tileWidthPx)
-    struct PendingInfo { size_t tileID; size_t sampleCount; int tileWidth; };
+    // Tiles waiting to be scheduled: key -> (tileID, sampleCount, tileWidthPx,
+    // tileHeightPx). The height is captured with the key rather than read at
+    // dispatch: the derived-plot height slider can move during the debounce
+    // window, and rendering at the new height under a key minted for the old
+    // one caches a pixmap that paintMid later blits with a mismatched source
+    // rect.
+    struct PendingInfo { size_t tileID; size_t sampleCount; int tileWidth; int tileHeight; };
     QHash<QString, PendingInfo> pendingInfo;
     // Keys desired in the current paint frame (for early-exit)
     QSet<QString> currentFrameKeys;


### PR DESCRIPTION
## Summary

Three related fixes to the derived-plot rendering path.

**Fix aliased trace decimation.** `TracePlot` picked one sample per pixel column, so any component faster than the pixel rate (e.g. an IQ carrier at a few px/cycle) folded down and rendered as a convincing low-frequency waveform. Now it draws every sample up to 16 samples/px, and an honest per-column min/max envelope beyond that — in both the complex tile path and the async float renderer. Envelope columns with no finite samples break the path, matching the old NaN gap handling.

**Raw (pre-tuner) plot menu.** New right-click "Add raw plot (pre-filter)" submenu offering the complex-compatible plots on the raw `InputSource`, bypassing the `TunerTransform`. Useful for seeing low-level detail such as PA ramp-up without the tuner FIR's transients and passband shaping. Adding a raw plot does not move the tuner.

**Selection cursors on derived plots.** Time-selection cursors are now drawn over the derived plots, not just the spectrogram.

## Test plan

- [x] `cmake --build build -j` clean
- [ ] Visual check: IQ plot of a carrier at several px/cycle no longer shows a phantom low-frequency wave
- [ ] Raw plot submenu adds a plot fed from the untuned source